### PR TITLE
Fix construcor private in a_tensor_func.hpp

### DIFF
--- a/src/include/a_tensor_func.hpp
+++ b/src/include/a_tensor_func.hpp
@@ -14,9 +14,11 @@
 /// @tparam T the type of the data contained in the tensor. E.g. int, float,
 template <typename T>
 class TensorFunction {
-public:
-    /// @brief Default constructor for TensorFunction.
+    protected:
+    /// @brief Construct a new TensorFunction object.
     explicit TensorFunction() = default;
+   
+    public:
 
     /// @brief Virtual destructor for TensorFunction.
     /// @details Ensures derived class destructors are called properly.


### PR DESCRIPTION

### Description
Made construcor private in a_tensor_func.hpp

This was a very minor hotfix