### PR TITLE
Add some abbreviations and function wrappers to remove ugly std:: calls

### DIFF
--- a/src/include/a_arithmetic_module.hpp
+++ b/src/include/a_arithmetic_module.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>  // Include memory for std::unique_ptr
+#include <memory>  // Include memory for UPtr
 #include <type_traits>
 
 #include "a_data_structure.hpp"
@@ -29,38 +29,37 @@ class ArithmeticModule {
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return The result of adding the two data structures.
-  virtual std::unique_ptr<DataStructure<T>> add(const std::unique_ptr<DataStructure<T>> a, const std::unique_ptr<DataStructure<T>> b) const = 0;
+  virtual UPtr<DataStructure<T>> add(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
 
   /// @brief Subtract one data structure from another.
   /// @param a The data structure to subtract from.
   /// @param b The data structure to subtract.
   /// @return The result of subtracting the second data structure from the first.
-  virtual std::unique_ptr<DataStructure<T>> subtract(const std::unique_ptr<DataStructure<T>> a, const std::unique_ptr<DataStructure<T>> b) const = 0;
+  virtual UPtr<DataStructure<T>> subtract(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
 
   /// @brief Multiply two data structures.
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return The result of multiplying the two data structures.
-  virtual std::unique_ptr<DataStructure<T>> multiply(const std::unique_ptr<DataStructure<T>> a, const std::unique_ptr<DataStructure<T>> b) const = 0;
+  virtual UPtr<DataStructure<T>> multiply(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
 
   /// @brief Multiply a data structure by a scalar.
   /// @param a The data structure.
   /// @param b The scalar value.
   /// @return The result of multiplying the data structure by the scalar.
-  virtual std::unique_ptr<DataStructure<T>> multiply(const std::unique_ptr<DataStructure<T>> a, const T b) const = 0;
+  virtual UPtr<DataStructure<T>> multiply(const UPtr<DataStructure<T>> a, const T b) const = 0;
 
   /// @brief Divide a data structure by a scalar.
   /// @param a The data structure.
   /// @param b The scalar value.
   /// @return The result of dividing the data structure by the scalar.
-  virtual std::unique_ptr<DataStructure<T>> divide(const std::unique_ptr<DataStructure<T>> a, const T b) const = 0;
+  virtual UPtr<DataStructure<T>> divide(const UPtr<DataStructure<T>> a, const T b) const = 0;
 
   /// @brief Check if two data structures are equal.
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return True if the data structures are equal, false otherwise.
-  virtual bool equals(const std::unique_ptr<DataStructure<T>> a, const std::unique_ptr<DataStructure<T>> b) const = 0;
+  virtual bool equals(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
 
-  virtual std::unique_ptr<ArithmeticModule<T>> clone() const = 0;
-
+  virtual UPtr<ArithmeticModule<T>> clone() const = 0;
 };

--- a/src/include/a_arithmetic_module.hpp
+++ b/src/include/a_arithmetic_module.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>  // Include memory for UPtr
+// Include memory for unique_ptr
 #include <type_traits>
 
 #include "a_data_structure.hpp"
@@ -29,37 +29,37 @@ class ArithmeticModule {
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return The result of adding the two data structures.
-  virtual UPtr<DataStructure<T>> add(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
+  virtual unique_ptr<DataStructure<T>> add(const unique_ptr<DataStructure<T>> a, const unique_ptr<DataStructure<T>> b) const = 0;
 
   /// @brief Subtract one data structure from another.
   /// @param a The data structure to subtract from.
   /// @param b The data structure to subtract.
   /// @return The result of subtracting the second data structure from the first.
-  virtual UPtr<DataStructure<T>> subtract(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
+  virtual unique_ptr<DataStructure<T>> subtract(const unique_ptr<DataStructure<T>> a, const unique_ptr<DataStructure<T>> b) const = 0;
 
   /// @brief Multiply two data structures.
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return The result of multiplying the two data structures.
-  virtual UPtr<DataStructure<T>> multiply(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
+  virtual unique_ptr<DataStructure<T>> multiply(const unique_ptr<DataStructure<T>> a, const unique_ptr<DataStructure<T>> b) const = 0;
 
   /// @brief Multiply a data structure by a scalar.
   /// @param a The data structure.
   /// @param b The scalar value.
   /// @return The result of multiplying the data structure by the scalar.
-  virtual UPtr<DataStructure<T>> multiply(const UPtr<DataStructure<T>> a, const T b) const = 0;
+  virtual unique_ptr<DataStructure<T>> multiply(const unique_ptr<DataStructure<T>> a, const T b) const = 0;
 
   /// @brief Divide a data structure by a scalar.
   /// @param a The data structure.
   /// @param b The scalar value.
   /// @return The result of dividing the data structure by the scalar.
-  virtual UPtr<DataStructure<T>> divide(const UPtr<DataStructure<T>> a, const T b) const = 0;
+  virtual unique_ptr<DataStructure<T>> divide(const unique_ptr<DataStructure<T>> a, const T b) const = 0;
 
   /// @brief Check if two data structures are equal.
   /// @param a The first data structure.
   /// @param b The second data structure.
   /// @return True if the data structures are equal, false otherwise.
-  virtual bool equals(const UPtr<DataStructure<T>> a, const UPtr<DataStructure<T>> b) const = 0;
+  virtual bool equals(const unique_ptr<DataStructure<T>> a, const unique_ptr<DataStructure<T>> b) const = 0;
 
-  virtual UPtr<ArithmeticModule<T>> clone() const = 0;
+  virtual unique_ptr<ArithmeticModule<T>> clone() const = 0;
 };

--- a/src/include/a_data_parser.hpp
+++ b/src/include/a_data_parser.hpp
@@ -15,7 +15,7 @@ class DataParser {
    *
    * @param data JSON data of a Model.
    */
-  virtual UPtr<Model<T>> parse(const Data& data) const = 0;
+  virtual unique_ptr<Model<T>> parse(const Data& data) const = 0;
 
   /// @brief Virtual destructor for cleanup.
   virtual ~DataParser() = default;

--- a/src/include/a_data_parser.hpp
+++ b/src/include/a_data_parser.hpp
@@ -15,7 +15,7 @@ class DataParser {
    *
    * @param data JSON data of a Model.
    */
-  virtual unique_ptr<Model<T>> parse(const Data& data) const = 0;
+  virtual unique_ptr<Model<T>> parse(const json& data) const = 0;
 
   /// @brief Virtual destructor for cleanup.
   virtual ~DataParser() = default;

--- a/src/include/a_data_parser.hpp
+++ b/src/include/a_data_parser.hpp
@@ -1,23 +1,22 @@
 #pragma once
 
-#include "globals.hpp"
 #include "a_model.hpp"
+#include "globals.hpp"
 
 /**
  * @class DataParser
  * @brief Abstract class for parsing JSON data of a model into a Model Object.
  */
 template <typename T>
-class DataParser
-{
-  public:
-    /**
-     * @brief Parses JSON data of a model into a Model object.
-     * 
-     * @param data JSON data of a Model.
-     */
-    virtual std::unique_ptr<Model<T>> parse(const Data& data) const = 0;
-    
-    /// @brief Virtual destructor for cleanup.
-    virtual ~DataParser() = default;
+class DataParser {
+ public:
+  /**
+   * @brief Parses JSON data of a model into a Model object.
+   *
+   * @param data JSON data of a Model.
+   */
+  virtual UPtr<Model<T>> parse(const Data& data) const = 0;
+
+  /// @brief Virtual destructor for cleanup.
+  virtual ~DataParser() = default;
 };

--- a/src/include/a_data_structure.hpp
+++ b/src/include/a_data_structure.hpp
@@ -24,14 +24,14 @@ class DataStructure {
   virtual ~DataStructure() = default;
 
   /// @brief Set the data of the data structure.
-  /// @param data a vectortor of data to get_mutable_elem in the data structure.
+  /// @param data a vector of data to get_mutable_elem in the data structure.
   virtual void set_data(const vector<T> data) = 0;
 
   /// @brief Set all elements in the data structure to zero.
   virtual void set_zero() = 0;
 
   /// @brief Get the shape of the data structure.
-  /// @return a vectortor of integers representing the shape.
+  /// @return a vector of integers representing the shape.
   virtual const vector<int>& get_shape() const = 0;
 
   /// @brief Get the shape as a string. E.g. [2, 3, 4].
@@ -43,16 +43,16 @@ class DataStructure {
   virtual int get_data_size() const = 0;
 
   /// @brief Get the raw data of the data structure flattened in row-major order.
-  /// @return a vectortor of the raw data.
+  /// @return a vector of the raw data.
   const virtual vector<T>& get_raw_data() const = 0;
 
   /// @brief Get an element from the data structure.
-  /// @param indices a vectortor of integers representing the indices of the data structure.
+  /// @param indices a vector of integers representing the indices of the data structure.
   /// @return a value from the data structure.
   virtual const T& get_elem(vector<int> indices) const = 0;
 
   /// @brief Set an element in the data structure.
-  /// @param indices a vectortor of integers representing the indices of the data structure.
+  /// @param indices a vector of integers representing the indices of the data structure.
   virtual T& get_mutable_elem(vector<int> indices) = 0;
 
   virtual unique_ptr<DataStructure<T>> clone() const = 0;

--- a/src/include/a_data_structure.hpp
+++ b/src/include/a_data_structure.hpp
@@ -55,5 +55,5 @@ class DataStructure {
   /// @param indices a vector of integers representing the indices of the data structure.
   virtual T& get_mutable_elem(Vec<int> indices) = 0;
 
-  virtual std::unique_ptr<DataStructure<T>> clone() const = 0;
+  virtual UPtr<DataStructure<T>> clone() const = 0;
 };

--- a/src/include/a_data_structure.hpp
+++ b/src/include/a_data_structure.hpp
@@ -24,36 +24,36 @@ class DataStructure {
   virtual ~DataStructure() = default;
 
   /// @brief Set the data of the data structure.
-  /// @param data a vector of data to get_mutable_elem in the data structure.
-  virtual void set_data(const Vec<T> data) = 0;
+  /// @param data a vectortor of data to get_mutable_elem in the data structure.
+  virtual void set_data(const vector<T> data) = 0;
 
   /// @brief Set all elements in the data structure to zero.
   virtual void set_zero() = 0;
 
   /// @brief Get the shape of the data structure.
-  /// @return a vector of integers representing the shape.
-  virtual const Vec<int>& get_shape() const = 0;
+  /// @return a vectortor of integers representing the shape.
+  virtual const vector<int>& get_shape() const = 0;
 
   /// @brief Get the shape as a string. E.g. [2, 3, 4].
   /// @return a string representation of the shape.
-  virtual String get_shape_str() const = 0;
+  virtual string get_shape_str() const = 0;
 
   /// @brief Gets the amount of elements in the data structure.
   /// @return the size of the data structure as an integer.
   virtual int get_data_size() const = 0;
 
   /// @brief Get the raw data of the data structure flattened in row-major order.
-  /// @return a vector of the raw data.
-  const virtual Vec<T>& get_raw_data() const = 0;
+  /// @return a vectortor of the raw data.
+  const virtual vector<T>& get_raw_data() const = 0;
 
   /// @brief Get an element from the data structure.
-  /// @param indices a vector of integers representing the indices of the data structure.
+  /// @param indices a vectortor of integers representing the indices of the data structure.
   /// @return a value from the data structure.
-  virtual const T& get_elem(Vec<int> indices) const = 0;
+  virtual const T& get_elem(vector<int> indices) const = 0;
 
   /// @brief Set an element in the data structure.
-  /// @param indices a vector of integers representing the indices of the data structure.
-  virtual T& get_mutable_elem(Vec<int> indices) = 0;
+  /// @param indices a vectortor of integers representing the indices of the data structure.
+  virtual T& get_mutable_elem(vector<int> indices) = 0;
 
-  virtual UPtr<DataStructure<T>> clone() const = 0;
+  virtual unique_ptr<DataStructure<T>> clone() const = 0;
 };

--- a/src/include/a_layer.hpp
+++ b/src/include/a_layer.hpp
@@ -27,7 +27,7 @@ class Layer {
 
   /// @brief Returns the activation function of the layer.
   /// @return A TensorFunction<T> representing the layer's activation.
-  virtual UPtr<TensorFunction<T>> activation() const = 0;
+  virtual unique_ptr<TensorFunction<T>> activation() const = 0;
 
   /// @brief Computes the forward pass through the layer.
   /// @param input The input tensor.

--- a/src/include/a_layer.hpp
+++ b/src/include/a_layer.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-
-#include "a_tensor_func.hpp" // Needed for activation functions
-#include "tensor.hpp"        // Needed for Tensor<T>
-
+#include "a_tensor_func.hpp"  // Needed for activation functions
+#include "tensor.hpp"         // Needed for Tensor<T>
 
 /**
  * @class Layer
@@ -15,24 +13,24 @@
  */
 template <typename T>
 class Layer {
-protected:
-    /// @brief Default constructor.
-    explicit Layer() = default;
+ protected:
+  /// @brief Default constructor.
+  explicit Layer() = default;
 
-public:
-    /// @brief Virtual destructor ensures proper cleanup in derived classes.
-    virtual ~Layer() = default;
+ public:
+  /// @brief Virtual destructor ensures proper cleanup in derived classes.
+  virtual ~Layer() = default;
 
-    /// @brief Returns the tensor representation of the layer.
-    /// @return A Tensor<T> object representing the layer's parameters.
-    virtual Tensor<T> tensor() const = 0;
+  /// @brief Returns the tensor representation of the layer.
+  /// @return A Tensor<T> object representing the layer's parameters.
+  virtual Tensor<T> tensor() const = 0;
 
-    /// @brief Returns the activation function of the layer. 
-    /// @return A TensorFunction<T> representing the layer's activation.
-    virtual std::unique_ptr<TensorFunction<T>>activation() const = 0;
+  /// @brief Returns the activation function of the layer.
+  /// @return A TensorFunction<T> representing the layer's activation.
+  virtual UPtr<TensorFunction<T>> activation() const = 0;
 
-    /// @brief Computes the forward pass through the layer.
-    /// @param input The input tensor.
-    /// @return The output tensor after applying the layer's transformation.
-    virtual Tensor<T> forward(const Tensor<T>& input) const = 0;
+  /// @brief Computes the forward pass through the layer.
+  /// @param input The input tensor.
+  /// @return The output tensor after applying the layer's transformation.
+  virtual Tensor<T> forward(const Tensor<T>& input) const = 0;
 };

--- a/src/include/a_model.hpp
+++ b/src/include/a_model.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <vector>
-
 #include "a_layer.hpp"
-#include "tensor.hpp"
 #include "globals.hpp"
-
+#include "tensor.hpp"
 
 /**
  * @class Model
@@ -21,7 +18,7 @@ class Model {
  protected:
   /// @brief Dynamic array of Layers
   /// @details Structure to be defined for each derived model
-  Vec<Layer<T>> layers;
+  vector<Layer<T>> layers;
 
   /// @brief Default constructor for Model.
   explicit Model() = default;

--- a/src/include/globals.hpp
+++ b/src/include/globals.hpp
@@ -5,11 +5,9 @@
 #include <string>
 #include <vector>
 
-// Aliases for common types
-using Data = nlohmann::json;
-
+using nlohmann::json;
 using std::make_unique;
 using std::move;
+using std::string;
 using std::unique_ptr;
 using std::vector;
-using std::string;

--- a/src/include/globals.hpp
+++ b/src/include/globals.hpp
@@ -9,6 +9,7 @@ template <typename T>
 using Vec = std::vector<T>;
 using String = std::string;
 using Data = nlohmann::json;
+
 template <typename T>
 using UPtr = std::unique_ptr<T>;
 template <typename T>
@@ -16,23 +17,12 @@ using SPtr = std::shared_ptr<T>;
 template <typename T>
 using WPtr = std::weak_ptr<T>;
 
-// utility functions
-namespace util {
-    /// @brief Makes a unique pointer from a raw pointer.
-    /// @tparam T The type of the object to be wrapped.
-    /// @param ptr The raw pointer to be wrapped.
-    /// @return A unique pointer to the object.
-    template <typename T>
-    UPtr<T> make_UPr() {
-        return std::make_unique<T>();
-    }
+template <typename T, typename... Args>
+UPtr<T> make_UPtr(Args&&... args) {
+  return std::make_unique<T>(std::forward<Args>(args)...);
+}
 
-    /// @brief Moves a unique pointer
-    /// @tparam T The type of the object to be moved.
-    /// @param ptr The unique pointer to be moved.
-    /// @return A unique pointer to the object.
-    template <typename T>
-    UPtr<T> move_UPr(UPtr<T>& ptr) {
-        return std::move(ptr);
-    }
+template <typename T>
+decltype(auto) move_Ptr(T&& obj) {
+  return std::move(obj);
 }

--- a/src/include/globals.hpp
+++ b/src/include/globals.hpp
@@ -1,28 +1,15 @@
 #pragma once
+
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
 // Aliases for common types
-template <typename T>
-using Vec = std::vector<T>;
-using String = std::string;
 using Data = nlohmann::json;
 
-template <typename T>
-using UPtr = std::unique_ptr<T>;
-template <typename T>
-using SPtr = std::shared_ptr<T>;
-template <typename T>
-using WPtr = std::weak_ptr<T>;
-
-template <typename T, typename... Args>
-UPtr<T> make_UPtr(Args&&... args) {
-  return std::make_unique<T>(std::forward<Args>(args)...);
-}
-
-template <typename T>
-decltype(auto) move_Ptr(T&& obj) {
-  return std::move(obj);
-}
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+using std::vector;
+using std::string;

--- a/src/include/globals.hpp
+++ b/src/include/globals.hpp
@@ -4,7 +4,35 @@
 #include <string>
 #include <vector>
 
+// Aliases for common types
 template <typename T>
 using Vec = std::vector<T>;
 using String = std::string;
 using Data = nlohmann::json;
+template <typename T>
+using UPtr = std::unique_ptr<T>;
+template <typename T>
+using SPtr = std::shared_ptr<T>;
+template <typename T>
+using WPtr = std::weak_ptr<T>;
+
+// utility functions
+namespace util {
+    /// @brief Makes a unique pointer from a raw pointer.
+    /// @tparam T The type of the object to be wrapped.
+    /// @param ptr The raw pointer to be wrapped.
+    /// @return A unique pointer to the object.
+    template <typename T>
+    UPtr<T> make_UPr() {
+        return std::make_unique<T>();
+    }
+
+    /// @brief Moves a unique pointer
+    /// @tparam T The type of the object to be moved.
+    /// @param ptr The unique pointer to be moved.
+    /// @return A unique pointer to the object.
+    template <typename T>
+    UPtr<T> move_UPr(UPtr<T>& ptr) {
+        return std::move(ptr);
+    }
+}

--- a/src/include/mml_arithmetic.hpp
+++ b/src/include/mml_arithmetic.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <memory>  // Include memory for UPtr
 
 #include "a_arithmetic_module.hpp"
 #include "a_data_structure.hpp"
@@ -19,50 +18,50 @@ class Arithmetic_mml : public ArithmeticModule<float> {
   // Override copy constructor
   Arithmetic_mml(const Arithmetic_mml&) = default;
 
-  UPtr<DataStructure<float>> add(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
+  unique_ptr<DataStructure<float>> add(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {
     const auto& a_raw = a->get_raw_data();
     const auto& b_raw = b->get_raw_data();
-    auto res_raw = Vec<float>(a->get_data_size(), 0);
+    auto res_raw = vector<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] + b_raw[i];
     }
-    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
   }
 
-  UPtr<DataStructure<float>> subtract(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
+  unique_ptr<DataStructure<float>> subtract(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {
     const auto& a_raw = a->get_raw_data();
     const auto& b_raw = b->get_raw_data();
-    auto res_raw = Vec<float>(a->get_data_size(), 0);
+    auto res_raw = vector<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] - b_raw[i];
     }
-    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
   }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-  UPtr<DataStructure<float>> multiply(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
+  unique_ptr<DataStructure<float>> multiply(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {
     return nullptr;  // TODO: Implement this
   }
 
-  UPtr<DataStructure<float>> multiply(const UPtr<DataStructure<float>> a, const float b) const override {
+  unique_ptr<DataStructure<float>> multiply(const unique_ptr<DataStructure<float>> a, const float b) const override {
     const auto& a_raw = a->get_raw_data();
-    auto res_raw = Vec<float>(a->get_data_size(), 0);
+    auto res_raw = vector<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] * b;
     }
-    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
   }
 
-  UPtr<DataStructure<float>> divide(const UPtr<DataStructure<float>> a, const float b) const override {
+  unique_ptr<DataStructure<float>> divide(const unique_ptr<DataStructure<float>> a, const float b) const override {
     const auto& a_raw = a->get_raw_data();
-    auto res_raw = Vec<float>(a->get_data_size(), 0);
+    auto res_raw = vector<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] / b;
     }
-    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
   }
 
-  bool equals(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
+  bool equals(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {
     if (bool same_shape = a->get_shape() == b->get_shape(); !same_shape) {
       return false;
     }
@@ -76,8 +75,8 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     return true;
   }
 
-  UPtr<ArithmeticModule<float>> clone() const override {
-    return make_UPtr<Arithmetic_mml>(*this);
+  unique_ptr<ArithmeticModule<float>> clone() const override {
+    return make_unique<Arithmetic_mml>(*this);
   }
 
  private:

--- a/src/include/mml_arithmetic.hpp
+++ b/src/include/mml_arithmetic.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <memory>  // Include memory for std::unique_ptr
+#include <memory>  // Include memory for UPtr
 
 #include "a_arithmetic_module.hpp"
 #include "a_data_structure.hpp"
+#include "globals.hpp"
 #include "mml_vector.hpp"
 
 class Arithmetic_mml : public ArithmeticModule<float> {
@@ -18,50 +19,50 @@ class Arithmetic_mml : public ArithmeticModule<float> {
   // Override copy constructor
   Arithmetic_mml(const Arithmetic_mml&) = default;
 
-  std::unique_ptr<DataStructure<float>> add(const std::unique_ptr<DataStructure<float>> a, const std::unique_ptr<DataStructure<float>> b) const override {
+  UPtr<DataStructure<float>> add(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
     const auto& a_raw = a->get_raw_data();
     const auto& b_raw = b->get_raw_data();
     auto res_raw = Vec<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] + b_raw[i];
     }
-    return std::make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
-  std::unique_ptr<DataStructure<float>> subtract(const std::unique_ptr<DataStructure<float>> a, const std::unique_ptr<DataStructure<float>> b) const override {
+  UPtr<DataStructure<float>> subtract(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
     const auto& a_raw = a->get_raw_data();
     const auto& b_raw = b->get_raw_data();
     auto res_raw = Vec<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] - b_raw[i];
     }
-    return std::make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-  std::unique_ptr<DataStructure<float>> multiply(const std::unique_ptr<DataStructure<float>> a, const std::unique_ptr<DataStructure<float>> b) const override {
+  UPtr<DataStructure<float>> multiply(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
     return nullptr;  // TODO: Implement this
   }
 
-  std::unique_ptr<DataStructure<float>> multiply(const std::unique_ptr<DataStructure<float>> a, const float b) const override {
+  UPtr<DataStructure<float>> multiply(const UPtr<DataStructure<float>> a, const float b) const override {
     const auto& a_raw = a->get_raw_data();
     auto res_raw = Vec<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] * b;
     }
-    return std::make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
-  std::unique_ptr<DataStructure<float>> divide(const std::unique_ptr<DataStructure<float>> a, const float b) const override {
+  UPtr<DataStructure<float>> divide(const UPtr<DataStructure<float>> a, const float b) const override {
     const auto& a_raw = a->get_raw_data();
     auto res_raw = Vec<float>(a->get_data_size(), 0);
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] / b;
     }
-    return std::make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
+    return make_UPtr<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
-  bool equals(const std::unique_ptr<DataStructure<float>> a, const std::unique_ptr<DataStructure<float>> b) const override {
+  bool equals(const UPtr<DataStructure<float>> a, const UPtr<DataStructure<float>> b) const override {
     if (bool same_shape = a->get_shape() == b->get_shape(); !same_shape) {
       return false;
     }
@@ -75,8 +76,8 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     return true;
   }
 
-  std::unique_ptr<ArithmeticModule<float>> clone() const override {
-    return std::make_unique<Arithmetic_mml>(*this);
+  UPtr<ArithmeticModule<float>> clone() const override {
+    return make_UPtr<Arithmetic_mml>(*this);
   }
 
  private:

--- a/src/include/mml_arithmetic.hpp
+++ b/src/include/mml_arithmetic.hpp
@@ -25,7 +25,7 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] + b_raw[i];
     }
-    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
   unique_ptr<DataStructure<float>> subtract(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {
@@ -35,7 +35,7 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] - b_raw[i];
     }
-    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -49,7 +49,7 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] * b;
     }
-    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
   unique_ptr<DataStructure<float>> divide(const unique_ptr<DataStructure<float>> a, const float b) const override {
@@ -58,7 +58,7 @@ class Arithmetic_mml : public ArithmeticModule<float> {
     for (int i = 0; i < a->get_data_size(); i++) {
       res_raw[i] = a_raw[i] / b;
     }
-    return make_unique<vectortor_mml<float>>(a->get_shape(), res_raw);
+    return make_unique<Vector_mml<float>>(a->get_shape(), res_raw);
   }
 
   bool equals(const unique_ptr<DataStructure<float>> a, const unique_ptr<DataStructure<float>> b) const override {

--- a/src/include/mml_tensors.hpp
+++ b/src/include/mml_tensors.hpp
@@ -5,6 +5,6 @@
 #include "mml_vector.hpp"
 #include "tensor.hpp"
 
-Tensor<float> tensor_mll(Vec<int> shape);
+Tensor<float> tensor_mll(vector<int> shape);
 
-Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float> data);
+Tensor<float> tensor_mll(const vector<int> shape, const vector<float> data);

--- a/src/include/mml_vector.hpp
+++ b/src/include/mml_vector.hpp
@@ -7,27 +7,27 @@
 #include "globals.hpp"
 
 template <typename T>
-class vectortor_mml : public DataStructure<T> {
+class Vector_mml : public DataStructure<T> {
  public:
-  vectortor_mml(vector<int> const& shape, vector<T> data) : DataStructure<T>(), data(data), shape(shape) {
+  Vector_mml(vector<int> const& shape, vector<T> data) : DataStructure<T>(), data(data), shape(shape) {
     this->offsets = compute_offsets();
   }
 
-  explicit vectortor_mml(vector<int> const& shape) : DataStructure<T>(), shape(shape) {
+  explicit Vector_mml(vector<int> const& shape) : DataStructure<T>(), shape(shape) {
     const int size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int>());
     this->data = vector<T>(size, 0);
     this->offsets = compute_offsets();
   }
 
   // Override move constructor
-  vectortor_mml(vectortor_mml&& other) noexcept
+  Vector_mml(Vector_mml&& other) noexcept
       : data(move(other.data)), shape(move(other.shape)), offsets(move(other.offsets)) {}
 
   // Override copy constructor
-  vectortor_mml(const vectortor_mml& other)
+  Vector_mml(const Vector_mml& other)
       : data(other.data), shape(other.shape), offsets(other.offsets) {}
 
-  ~vectortor_mml() override = default;
+  ~Vector_mml() override = default;
 
   void set_data(const vector<T> new_data) override {
     this->data = new_data;
@@ -70,7 +70,7 @@ class vectortor_mml : public DataStructure<T> {
   }
 
   unique_ptr<DataStructure<T>> clone() const override {
-    return make_unique<vectortor_mml<T>>(*this);
+    return make_unique<Vector_mml<T>>(*this);
   }
 
  private:
@@ -94,7 +94,7 @@ class vectortor_mml : public DataStructure<T> {
     return true;
   }
 
-  /// @brief Calculates the index of an element in the flat vectortor containing the data.
+  /// @brief Calculates the index of an element in the flat vector containing the data.
   /// @param indices The indices to get the index for.
   /// @return The index.
   int index_with_offset(vector<int> indices) const {
@@ -107,7 +107,7 @@ class vectortor_mml : public DataStructure<T> {
   }
 
   /// @brief Row-major offsets for the data structure.
-  /// @return a vectortor of integers representing the offsets.
+  /// @return a vector of integers representing the offsets.
   vector<int> compute_offsets() const {
     const int size = static_cast<int>(shape.size());
     auto computed_offsets = vector<int>(size, 1);

--- a/src/include/mml_vector.hpp
+++ b/src/include/mml_vector.hpp
@@ -21,7 +21,7 @@ class Vector_mml : public DataStructure<T> {
 
   // Override move constructor
   Vector_mml(Vector_mml&& other) noexcept
-      : data(std::move(other.data)), shape(std::move(other.shape)), offsets(std::move(other.offsets)) {}
+      : data(move_Ptr(other.data)), shape(move_Ptr(other.shape)), offsets(move_Ptr(other.offsets)) {}
 
   // Override copy constructor
   Vector_mml(const Vector_mml& other)
@@ -69,8 +69,8 @@ class Vector_mml : public DataStructure<T> {
     }
   }
 
-  std::unique_ptr<DataStructure<T>> clone() const override {
-    return std::make_unique<Vector_mml<T>>(*this);
+  UPtr<DataStructure<T>> clone() const override {
+    return make_UPtr<Vector_mml<T>>(*this);
   }
 
  private:

--- a/src/include/mml_vector.hpp
+++ b/src/include/mml_vector.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <memory>
+
 #include <numeric>
 #include <stdexcept>
 
@@ -7,41 +7,41 @@
 #include "globals.hpp"
 
 template <typename T>
-class Vector_mml : public DataStructure<T> {
+class vectortor_mml : public DataStructure<T> {
  public:
-  Vector_mml(Vec<int> const& shape, Vec<T> data) : DataStructure<T>(), data(data), shape(shape) {
+  vectortor_mml(vector<int> const& shape, vector<T> data) : DataStructure<T>(), data(data), shape(shape) {
     this->offsets = compute_offsets();
   }
 
-  explicit Vector_mml(Vec<int> const& shape) : DataStructure<T>(), shape(shape) {
+  explicit vectortor_mml(vector<int> const& shape) : DataStructure<T>(), shape(shape) {
     const int size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int>());
-    this->data = Vec<T>(size, 0);
+    this->data = vector<T>(size, 0);
     this->offsets = compute_offsets();
   }
 
   // Override move constructor
-  Vector_mml(Vector_mml&& other) noexcept
-      : data(move_Ptr(other.data)), shape(move_Ptr(other.shape)), offsets(move_Ptr(other.offsets)) {}
+  vectortor_mml(vectortor_mml&& other) noexcept
+      : data(move(other.data)), shape(move(other.shape)), offsets(move(other.offsets)) {}
 
   // Override copy constructor
-  Vector_mml(const Vector_mml& other)
+  vectortor_mml(const vectortor_mml& other)
       : data(other.data), shape(other.shape), offsets(other.offsets) {}
 
-  ~Vector_mml() override = default;
+  ~vectortor_mml() override = default;
 
-  void set_data(const Vec<T> new_data) override {
+  void set_data(const vector<T> new_data) override {
     this->data = new_data;
   }
 
   void set_zero() override {
-    this->data = Vec<T>(this->data.size(), 0);
+    this->data = vector<T>(this->data.size(), 0);
   }
 
-  const Vec<int>& get_shape() const override {
+  const vector<int>& get_shape() const override {
     return this->shape;
   }
 
-  const Vec<T>& get_raw_data() const override {
+  const vector<T>& get_raw_data() const override {
     return this->data;
   }
 
@@ -49,11 +49,11 @@ class Vector_mml : public DataStructure<T> {
     return this->data.size();
   }
 
-  String get_shape_str() const override {
+  string get_shape_str() const override {
     return "[" + std::to_string(this->data.size()) + "]";
   }
 
-  const T& get_elem(Vec<int> indices) const override {
+  const T& get_elem(vector<int> indices) const override {
     if (!valid_index(indices)) {
       throw std::out_of_range("Invalid index");
     } else {
@@ -61,7 +61,7 @@ class Vector_mml : public DataStructure<T> {
     }
   }
 
-  T& get_mutable_elem(Vec<int> indices) override {
+  T& get_mutable_elem(vector<int> indices) override {
     if (!valid_index(indices)) {
       throw std::out_of_range("Invalid index");
     } else {
@@ -69,19 +69,19 @@ class Vector_mml : public DataStructure<T> {
     }
   }
 
-  UPtr<DataStructure<T>> clone() const override {
-    return make_UPtr<Vector_mml<T>>(*this);
+  unique_ptr<DataStructure<T>> clone() const override {
+    return make_unique<vectortor_mml<T>>(*this);
   }
 
  private:
-  Vec<T> data;
-  Vec<int> shape;
-  Vec<int> offsets;
+  vector<T> data;
+  vector<int> shape;
+  vector<int> offsets;
 
   /// @brief Check if the indices are valid. size of indices should be equal to the size of the shape. all elements of indices should be less than the corresponding element of the shape and greater than or equal to 0.
   /// @param indices The indices to check.
   /// @return True if the indices are valid, false otherwise.
-  bool valid_index(const Vec<int>& indices) const {
+  bool valid_index(const vector<int>& indices) const {
     if (indices.size() != this->shape.size()) {
       return false;
     }
@@ -94,10 +94,10 @@ class Vector_mml : public DataStructure<T> {
     return true;
   }
 
-  /// @brief Calculates the index of an element in the flat vector containing the data.
+  /// @brief Calculates the index of an element in the flat vectortor containing the data.
   /// @param indices The indices to get the index for.
   /// @return The index.
-  int index_with_offset(Vec<int> indices) const {
+  int index_with_offset(vector<int> indices) const {
     auto index = 0;
     const auto size = static_cast<int>(shape.size());
     for (int i = 0; i < size; i++) {
@@ -107,10 +107,10 @@ class Vector_mml : public DataStructure<T> {
   }
 
   /// @brief Row-major offsets for the data structure.
-  /// @return a vector of integers representing the offsets.
-  Vec<int> compute_offsets() const {
+  /// @return a vectortor of integers representing the offsets.
+  vector<int> compute_offsets() const {
     const int size = static_cast<int>(shape.size());
-    auto computed_offsets = Vec<int>(size, 1);
+    auto computed_offsets = vector<int>(size, 1);
     for (int i = size - 2; i >= 0; i--) {
       computed_offsets[i] = computed_offsets[i + 1] * this->shape[i];
     }

--- a/src/include/tensor.hpp
+++ b/src/include/tensor.hpp
@@ -18,7 +18,7 @@
     modules.
     @tparam T the type of the data contained in the tensor. E.g. int, float,
     double etc.
-    @tparam D the data structure used to store the data. E.g. std::vectortor,
+    @tparam D the data structure used to store the data. E.g. std::vector,
    std::array, or a custom data structure.
 */
 template <typename T>
@@ -53,7 +53,7 @@ class Tensor {
 
   /*!
       @brief Get the shape of the tensor.
-      @return A vectortor of integers representing the shape.
+      @return A vector of integers representing the shape.
   */
   vector<int> get_shape() {
     return this->data->get_shape();
@@ -167,7 +167,7 @@ class Tensor {
 
   /*!
       @brief Get an element from the tensor.
-      @param indices A vectortor of integers representing the indices of the element.
+      @param indices A vector of integers representing the indices of the element.
       @return The element at the given indices.
   */
   const T &operator[](vector<int> indices) const {
@@ -176,7 +176,7 @@ class Tensor {
 
   /*!
       @brief Set an element in the tensor.
-      @param indices A vectortor of integers representing the indices of the element.
+      @param indices A vector of integers representing the indices of the element.
       @return The tensor with the element get_mutable_elem.
   */
   T &operator[](vector<int> indices) {

--- a/src/include/tensor.hpp
+++ b/src/include/tensor.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <numeric>
 
 #include "a_arithmetic_module.hpp"
@@ -19,7 +18,7 @@
     modules.
     @tparam T the type of the data contained in the tensor. E.g. int, float,
     double etc.
-    @tparam D the data structure used to store the data. E.g. std::vector,
+    @tparam D the data structure used to store the data. E.g. std::vectortor,
    std::array, or a custom data structure.
 */
 template <typename T>
@@ -30,14 +29,14 @@ class Tensor {
       @param data Shared pointer to the data structure used to store the tensor data.
       @param am Unique pointer to the arithmetic module used to perform operations on the tensor data.
   */
-  Tensor(UPtr<DataStructure<T>> data, UPtr<ArithmeticModule<T>> am)
-      : data(move_Ptr(data)), am(move_Ptr(am)) {}
+  Tensor(unique_ptr<DataStructure<T>> data, unique_ptr<ArithmeticModule<T>> am)
+      : data(move(data)), am(move(am)) {}
 
   /*!
       @brief Move constructor.
   */
   Tensor(Tensor &&other) noexcept
-      : data(move_Ptr(other.data)), am(move_Ptr(other.am)) {}
+      : data(move(other.data)), am(move(other.am)) {}
 
   /*!
       @brief Copy constructor.
@@ -54,17 +53,17 @@ class Tensor {
 
   /*!
       @brief Get the shape of the tensor.
-      @return A vector of integers representing the shape.
+      @return A vectortor of integers representing the shape.
   */
-  Vec<int> get_shape() {
+  vector<int> get_shape() {
     return this->data->get_shape();
   }
 
   /*!
-      @brief Get the shape as a String.
-      @return A String representation of the shape. E.g. [2, 3, 4].
+      @brief Get the shape as a string.
+      @return A string representation of the shape. E.g. [2, 3, 4].
   */
-  String get_shape_str() const {
+  string get_shape_str() const {
     return this->data->get_shape_str();
   }
 
@@ -76,11 +75,11 @@ class Tensor {
       @return The result of adding the two tensors.
   */
   Tensor<T> operator+(const Tensor<T> &other) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
-    UPtr<DataStructure<T>> ds = this->am->add(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
-    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
+    unique_ptr<DataStructure<T>> ds = this->am->add(move(this_ds_copy), move(other_ds_copy));
+    unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move(ds), move(am_copy));
   }
 
   /*!
@@ -89,11 +88,11 @@ class Tensor {
       @return The result of subtracting the other tensor from this tensor.
   */
   Tensor<T> operator-(const Tensor<T> &other) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
-    UPtr<DataStructure<T>> ds = this->am->subtract(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
-    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
+    unique_ptr<DataStructure<T>> ds = this->am->subtract(move(this_ds_copy), move(other_ds_copy));
+    unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move(ds), move(am_copy));
   }
 
   /*!
@@ -102,11 +101,11 @@ class Tensor {
       @return The result of multiplying the two tensors.
   */
   Tensor<T> operator*(const Tensor<T> &other) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
-    UPtr<DataStructure<T>> ds = this->am->multiply(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
-    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
+    unique_ptr<DataStructure<T>> ds = this->am->multiply(move(this_ds_copy), move(other_ds_copy));
+    unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move(ds), move(am_copy));
   }
 
   /*!
@@ -115,10 +114,10 @@ class Tensor {
       @return The result of multiplying the tensor by the scalar.
   */
   Tensor<T> operator*(const T &scalar) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> ds = this->am->multiply(move_Ptr(this_ds_copy), move_Ptr(scalar));
-    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> ds = this->am->multiply(move(this_ds_copy), move(scalar));
+    unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move(ds), move(am_copy));
   }
 
   /*!
@@ -127,10 +126,10 @@ class Tensor {
       @return The result of dividing the tensor by the scalar.
   */
   Tensor<T> operator/(const T &scalar) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> ds = this->am->divide(move_Ptr(this_ds_copy), move_Ptr(scalar));
-    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> ds = this->am->divide(move(this_ds_copy), move(scalar));
+    unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move(ds), move(am_copy));
   }
 
   /*!
@@ -139,9 +138,9 @@ class Tensor {
       @return True if the tensors are equal, false otherwise.
   */
   bool operator==(const Tensor<T> &other) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
-    return this->am->equals(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
+    return this->am->equals(move(this_ds_copy), move(other_ds_copy));
   }
 
   /*!
@@ -150,9 +149,9 @@ class Tensor {
       @return True if the tensors are not equal, false otherwise.
   */
   bool operator!=(const Tensor<T> &other) const {
-    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
-    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
-    return !this->am->equals(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
+    unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
+    unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
+    return !this->am->equals(move(this_ds_copy), move(other_ds_copy));
   }
 
   /*!
@@ -160,34 +159,34 @@ class Tensor {
   */
   Tensor &operator=(Tensor &&other) noexcept {
     if (this != &other) {
-      data = move_Ptr(other.data);
-      am = move_Ptr(other.am);
+      data = move(other.data);
+      am = move(other.am);
     }
     return *this;
   }
 
   /*!
       @brief Get an element from the tensor.
-      @param indices A vector of integers representing the indices of the element.
+      @param indices A vectortor of integers representing the indices of the element.
       @return The element at the given indices.
   */
-  const T &operator[](Vec<int> indices) const {
+  const T &operator[](vector<int> indices) const {
     return this->data->get_elem(indices);
   }
 
   /*!
       @brief Set an element in the tensor.
-      @param indices A vector of integers representing the indices of the element.
+      @param indices A vectortor of integers representing the indices of the element.
       @return The tensor with the element get_mutable_elem.
   */
-  T &operator[](Vec<int> indices) {
+  T &operator[](vector<int> indices) {
     return this->data->get_mutable_elem(indices);
   }
 
  private:
   /// @brief Underlying data structure for the tensor.
-  UPtr<DataStructure<T>> data;
+  unique_ptr<DataStructure<T>> data;
 
   /// @brief Underlying arithmetic module for the tensor.
-  UPtr<ArithmeticModule<T>> am;
+  unique_ptr<ArithmeticModule<T>> am;
 };

--- a/src/include/tensor.hpp
+++ b/src/include/tensor.hpp
@@ -30,14 +30,14 @@ class Tensor {
       @param data Shared pointer to the data structure used to store the tensor data.
       @param am Unique pointer to the arithmetic module used to perform operations on the tensor data.
   */
-  Tensor(std::unique_ptr<DataStructure<T>> data, std::unique_ptr<ArithmeticModule<T>> am)
-      : data(std::move(data)), am(std::move(am)) {}
+  Tensor(UPtr<DataStructure<T>> data, UPtr<ArithmeticModule<T>> am)
+      : data(move_Ptr(data)), am(move_Ptr(am)) {}
 
   /*!
       @brief Move constructor.
   */
   Tensor(Tensor &&other) noexcept
-      : data(std::move(other.data)), am(std::move(other.am)) {}
+      : data(move_Ptr(other.data)), am(move_Ptr(other.am)) {}
 
   /*!
       @brief Copy constructor.
@@ -76,11 +76,11 @@ class Tensor {
       @return The result of adding the two tensors.
   */
   Tensor<T> operator+(const Tensor<T> &other) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
-    std::unique_ptr<DataStructure<T>> ds = this->am->add(std::move(this_ds_copy), std::move(other_ds_copy));
-    std::unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(std::move(ds), std::move(am_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
+    UPtr<DataStructure<T>> ds = this->am->add(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
+    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
   }
 
   /*!
@@ -89,11 +89,11 @@ class Tensor {
       @return The result of subtracting the other tensor from this tensor.
   */
   Tensor<T> operator-(const Tensor<T> &other) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
-    std::unique_ptr<DataStructure<T>> ds = this->am->subtract(std::move(this_ds_copy), std::move(other_ds_copy));
-    std::unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(std::move(ds), std::move(am_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
+    UPtr<DataStructure<T>> ds = this->am->subtract(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
+    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
   }
 
   /*!
@@ -102,11 +102,11 @@ class Tensor {
       @return The result of multiplying the two tensors.
   */
   Tensor<T> operator*(const Tensor<T> &other) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
-    std::unique_ptr<DataStructure<T>> ds = this->am->multiply(std::move(this_ds_copy), std::move(other_ds_copy));
-    std::unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(std::move(ds), std::move(am_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
+    UPtr<DataStructure<T>> ds = this->am->multiply(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
+    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
   }
 
   /*!
@@ -115,10 +115,10 @@ class Tensor {
       @return The result of multiplying the tensor by the scalar.
   */
   Tensor<T> operator*(const T &scalar) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> ds = this->am->multiply(std::move(this_ds_copy), std::move(scalar));
-    std::unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(std::move(ds), std::move(am_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> ds = this->am->multiply(move_Ptr(this_ds_copy), move_Ptr(scalar));
+    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
   }
 
   /*!
@@ -127,10 +127,10 @@ class Tensor {
       @return The result of dividing the tensor by the scalar.
   */
   Tensor<T> operator/(const T &scalar) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> ds = this->am->divide(std::move(this_ds_copy), std::move(scalar));
-    std::unique_ptr<ArithmeticModule<T>> am_copy = this->am->clone();
-    return Tensor<T>(std::move(ds), std::move(am_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> ds = this->am->divide(move_Ptr(this_ds_copy), move_Ptr(scalar));
+    UPtr<ArithmeticModule<T>> am_copy = this->am->clone();
+    return Tensor<T>(move_Ptr(ds), move_Ptr(am_copy));
   }
 
   /*!
@@ -139,9 +139,9 @@ class Tensor {
       @return True if the tensors are equal, false otherwise.
   */
   bool operator==(const Tensor<T> &other) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
-    return this->am->equals(std::move(this_ds_copy), std::move(other_ds_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
+    return this->am->equals(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
   }
 
   /*!
@@ -150,9 +150,9 @@ class Tensor {
       @return True if the tensors are not equal, false otherwise.
   */
   bool operator!=(const Tensor<T> &other) const {
-    std::unique_ptr<DataStructure<T>> this_ds_copy = this->data->clone();
-    std::unique_ptr<DataStructure<T>> other_ds_copy = other.data->clone();
-    return !this->am->equals(std::move(this_ds_copy), std::move(other_ds_copy));
+    UPtr<DataStructure<T>> this_ds_copy = this->data->clone();
+    UPtr<DataStructure<T>> other_ds_copy = other.data->clone();
+    return !this->am->equals(move_Ptr(this_ds_copy), move_Ptr(other_ds_copy));
   }
 
   /*!
@@ -160,8 +160,8 @@ class Tensor {
   */
   Tensor &operator=(Tensor &&other) noexcept {
     if (this != &other) {
-      data = std::move(other.data);
-      am = std::move(other.am);
+      data = move_Ptr(other.data);
+      am = move_Ptr(other.am);
     }
     return *this;
   }
@@ -186,8 +186,8 @@ class Tensor {
 
  private:
   /// @brief Underlying data structure for the tensor.
-  std::unique_ptr<DataStructure<T>> data;
+  UPtr<DataStructure<T>> data;
 
   /// @brief Underlying arithmetic module for the tensor.
-  std::unique_ptr<ArithmeticModule<T>> am;
+  UPtr<ArithmeticModule<T>> am;
 };

--- a/src/mml_tensors.cpp
+++ b/src/mml_tensors.cpp
@@ -3,28 +3,28 @@
 /// @brief Initializes a new tensor with the given shape and all elements set to zero.
 /// @param shape The shape of the tensor.
 /// @return A new tensor with the given shape and all elements set to zero.
-Tensor<float> tensor_mll(const Vec<int> shape) {  // NOSONAR - function signature is correct
-  auto ds = make_UPtr<Vector_mml<float>>(shape);
-  auto am = make_UPtr<Arithmetic_mml>();
-  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
+Tensor<float> tensor_mll(const vector<int> shape) {  // NOSONAR - function signature is correct
+  auto ds = make_unique<vectortor_mml<float>>(shape);
+  auto am = make_unique<Arithmetic_mml>();
+  return Tensor<float>(move(ds), move(am));
 }
 
 /// @brief Initializes a new tensor with the given shape and data.
 /// @param shape The shape of the tensor.
 /// @param data A reference to the data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
-Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float>& data) {  // NOSONAR - function signature is correct
-  auto ds = make_UPtr<Vector_mml<float>>(shape, data);
-  auto am = make_UPtr<Arithmetic_mml>();
-  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
+Tensor<float> tensor_mll(const vector<int> shape, const vector<float>& data) {  // NOSONAR - function signature is correct
+  auto ds = make_unique<vectortor_mml<float>>(shape, data);
+  auto am = make_unique<Arithmetic_mml>();
+  return Tensor<float>(move(ds), move(am));
 }
 
 /// @brief Initializes a new tensor with the given shape and data.
 /// @param shape The shape of the tensor.
 /// @param data The data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
-Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float> data) {  // NOSONAR - function signature is correct
-  auto ds = make_UPtr<Vector_mml<float>>(shape, data);
-  auto am = make_UPtr<Arithmetic_mml>();
-  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
+Tensor<float> tensor_mll(const vector<int> shape, const vector<float> data) {  // NOSONAR - function signature is correct
+  auto ds = make_unique<vectortor_mml<float>>(shape, data);
+  auto am = make_unique<Arithmetic_mml>();
+  return Tensor<float>(move(ds), move(am));
 }

--- a/src/mml_tensors.cpp
+++ b/src/mml_tensors.cpp
@@ -4,7 +4,7 @@
 /// @param shape The shape of the tensor.
 /// @return A new tensor with the given shape and all elements set to zero.
 Tensor<float> tensor_mll(const vector<int> shape) {  // NOSONAR - function signature is correct
-  auto ds = make_unique<vectortor_mml<float>>(shape);
+  auto ds = make_unique<Vector_mml<float>>(shape);
   auto am = make_unique<Arithmetic_mml>();
   return Tensor<float>(move(ds), move(am));
 }
@@ -14,7 +14,7 @@ Tensor<float> tensor_mll(const vector<int> shape) {  // NOSONAR - function signa
 /// @param data A reference to the data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
 Tensor<float> tensor_mll(const vector<int> shape, const vector<float>& data) {  // NOSONAR - function signature is correct
-  auto ds = make_unique<vectortor_mml<float>>(shape, data);
+  auto ds = make_unique<Vector_mml<float>>(shape, data);
   auto am = make_unique<Arithmetic_mml>();
   return Tensor<float>(move(ds), move(am));
 }
@@ -24,7 +24,7 @@ Tensor<float> tensor_mll(const vector<int> shape, const vector<float>& data) {  
 /// @param data The data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
 Tensor<float> tensor_mll(const vector<int> shape, const vector<float> data) {  // NOSONAR - function signature is correct
-  auto ds = make_unique<vectortor_mml<float>>(shape, data);
+  auto ds = make_unique<Vector_mml<float>>(shape, data);
   auto am = make_unique<Arithmetic_mml>();
   return Tensor<float>(move(ds), move(am));
 }

--- a/src/mml_tensors.cpp
+++ b/src/mml_tensors.cpp
@@ -4,9 +4,9 @@
 /// @param shape The shape of the tensor.
 /// @return A new tensor with the given shape and all elements set to zero.
 Tensor<float> tensor_mll(const Vec<int> shape) {  // NOSONAR - function signature is correct
-  auto ds = std::make_unique<Vector_mml<float>>(shape);
-  auto am = std::make_unique<Arithmetic_mml>();
-  return Tensor<float>(std::move(ds), std::move(am));
+  auto ds = make_UPtr<Vector_mml<float>>(shape);
+  auto am = make_UPtr<Arithmetic_mml>();
+  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
 }
 
 /// @brief Initializes a new tensor with the given shape and data.
@@ -14,9 +14,9 @@ Tensor<float> tensor_mll(const Vec<int> shape) {  // NOSONAR - function signatur
 /// @param data A reference to the data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
 Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float>& data) {  // NOSONAR - function signature is correct
-  auto ds = std::make_unique<Vector_mml<float>>(shape, data);
-  auto am = std::make_unique<Arithmetic_mml>();
-  return Tensor<float>(std::move(ds), std::move(am));
+  auto ds = make_UPtr<Vector_mml<float>>(shape, data);
+  auto am = make_UPtr<Arithmetic_mml>();
+  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
 }
 
 /// @brief Initializes a new tensor with the given shape and data.
@@ -24,7 +24,7 @@ Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float>& data) {  // NOS
 /// @param data The data to be set in the tensor.
 /// @return A new tensor with the given shape and data.
 Tensor<float> tensor_mll(const Vec<int> shape, const Vec<float> data) {  // NOSONAR - function signature is correct
-  auto ds = std::make_unique<Vector_mml<float>>(shape, data);
-  auto am = std::make_unique<Arithmetic_mml>();
-  return Tensor<float>(std::move(ds), std::move(am));
+  auto ds = make_UPtr<Vector_mml<float>>(shape, data);
+  auto am = make_UPtr<Arithmetic_mml>();
+  return Tensor<float>(move_Ptr(ds), move_Ptr(am));
 }

--- a/tests/test_mml_tensor.cpp
+++ b/tests/test_mml_tensor.cpp
@@ -3,7 +3,6 @@
 #include <modularml>
 #include <numeric>
 #include <random>
-#include <vector>
 
 #define assert_msg(name, condition)                         \
   if (!(condition)) {                                       \
@@ -12,20 +11,20 @@
   assert(condition);                                        \
   std::cout << name << ": " << (condition ? "Passed" : "Failed") << std::endl;
 
-Vec<float> random_vec_f(int size, float low, float max, int seed = 0) {
+vector<float> random_vector_f(int size, float low, float max, int seed = 0) {
   std::mt19937 gen(seed);
   std::uniform_real_distribution<float> dist(low, max);
-  Vec<float> v(size);
+  vector<float> v(size);
   for (int i = 0; i < size; i++) {
     v[i] = dist(gen);
   }
   return v;
 }
 
-Vec<int> random_vec_i(int size, int low, int max, int seed = 0) {
+vector<int> random_vector_i(int size, int low, int max, int seed = 0) {
   std::mt19937 gen(seed);
   std::uniform_int_distribution dist(low, max);
-  Vec<int> v(size);
+  vector<int> v(size);
   for (int i = 0; i < size; i++) {
     v[i] = dist(gen);
   }
@@ -46,7 +45,7 @@ int main() {
       assert_msg("Tensor inequality test", t0 != t1)
 
       // Test correct shape
-      const auto expected_shape = Vec<int>{3, 3};
+      const auto expected_shape = vector<int>{3, 3};
   assert_msg("Tensor shape test", t0.get_shape() == expected_shape)
 
       // Test adding two tensors
@@ -113,9 +112,9 @@ int main() {
     std::mt19937 gen(i);
     std::uniform_int_distribution dist(0, 99);
     int rand_int = dist(gen);
-    Vec<int> shape = random_vec_i(5, 1, 10, i);
+    vector<int> shape = random_vector_i(5, 1, 10, i);
     int data_size = accumulate(shape.begin(), shape.end(), 1, std::multiplies<int>());
-    Vec<float> data = random_vec_f(data_size, 1, 10, i);
+    vector<float> data = random_vector_f(data_size, 1, 10, i);
     Tensor<float> t = tensor_mll(shape, data);
     tensor_prop1(t);
     tensor_prop2(t);


### PR DESCRIPTION
### Description
Tiny issue, I just added some abbreviations and functions to globals and implemented them instead of the original std:: functions.

### Issue
Closes #47