### PR TITLE
Add concrete tensorfunction class

### DIFF
--- a/src/include/mml_TensorFunction_ReLU.hpp
+++ b/src/include/mml_TensorFunction_ReLU.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
 #include <cmath>
+#include <modularml>
 
-#include "a_tensor_func.hpp"
-#include "mml_elementwise.hpp"
 
 /**
  * @class mml_TensorFunction_ReLU.hpp

--- a/src/include/mml_TensorFunction_ReLU.hpp
+++ b/src/include/mml_TensorFunction_ReLU.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cmath>
+#include "a_tensor_func.hpp"
+#include "mml_elementwise.hpp"
+
+/**
+ * @class mml_TensorFunction_ReLU.hpp
+ * @brief A class that implements a tensor function for the tanH function.
+ */
+class mml_TensorFunction_ReLU : public TensorFunction<float> {
+    public:
+
+    /**
+     * @brief Apply the ReLU function to the given tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the ReLU function applied to each element.
+    */
+    Tensor<float> func(const Tensor<float>& t) const{
+        //Right now this code is just a placeholder
+        auto tensor = t;
+
+        return tensor;
+    }
+    /**
+     * @brief Apply the derivative of the ReLU function to the tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the derivative of ReLU applied to each element.
+    */
+    Tensor<float> derivative(const Tensor<float>& t) const{
+        auto tensor = t;
+        return elementwise_apply(tensor, [](float x) {
+            return (x > 0) ? 1.0f : 0.0f; // Defaults to 0, like TensorFlow does
+        });
+    }
+    /**
+     * @brief Apply the primitive of the ReLU function to the given tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the primitive of ReLU applied to each element.
+    */    
+    Tensor<float> primitive(const Tensor<float>& t) const{
+        auto tensor = t;
+        return elementwise_apply(tensor, [](float x) {
+            return (x > 0) ? (x * x) / 2.0f : 0.0f;
+        });
+    }
+};

--- a/src/include/mml_TensorFunction_ReLU.hpp
+++ b/src/include/mml_TensorFunction_ReLU.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cmath>
 #include <modularml>
 
 
@@ -17,10 +16,10 @@ class mml_TensorFunction_ReLU : public TensorFunction<float> {
    * @return A new tensor with the ReLU function applied to each element.
   */
   Tensor<float> func(const Tensor<float>& t) const {
-    // Right now this code is just a placeholder
     auto tensor = t;
-
-    return tensor;
+    return elementwise_apply(tensor, [](float x) {
+      return (x > 0) ? x : 0.0f;
+    });
   }
 
   /**

--- a/src/include/mml_TensorFunction_ReLU.hpp
+++ b/src/include/mml_TensorFunction_ReLU.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+
 #include "a_tensor_func.hpp"
 #include "mml_elementwise.hpp"
 
@@ -9,42 +10,42 @@
  * @brief A class that implements a tensor function for the tanH function.
  */
 class mml_TensorFunction_ReLU : public TensorFunction<float> {
-    public:
+ public:
+  /**
+   * @brief Apply the ReLU function to the given tensor.
 
-    /**
-     * @brief Apply the ReLU function to the given tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the ReLU function applied to each element.
-    */
-    Tensor<float> func(const Tensor<float>& t) const{
-        //Right now this code is just a placeholder
-        auto tensor = t;
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the ReLU function applied to each element.
+  */
+  Tensor<float> func(const Tensor<float>& t) const {
+    // Right now this code is just a placeholder
+    auto tensor = t;
 
-        return tensor;
-    }
-    /**
-     * @brief Apply the derivative of the ReLU function to the tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the derivative of ReLU applied to each element.
-    */
-    Tensor<float> derivative(const Tensor<float>& t) const{
-        auto tensor = t;
-        return elementwise_apply(tensor, [](float x) {
-            return (x > 0) ? 1.0f : 0.0f; // Defaults to 0, like TensorFlow does
-        });
-    }
-    /**
-     * @brief Apply the primitive of the ReLU function to the given tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the primitive of ReLU applied to each element.
-    */    
-    Tensor<float> primitive(const Tensor<float>& t) const{
-        auto tensor = t;
-        return elementwise_apply(tensor, [](float x) {
-            return (x > 0) ? (x * x) / 2.0f : 0.0f;
-        });
-    }
+    return tensor;
+  }
+
+  /**
+   * @brief Apply the derivative of the ReLU function to the tensor.
+
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the derivative of ReLU applied to each element.
+  */
+  Tensor<float> derivative(const Tensor<float>& t) const {
+    auto tensor = t;
+    return elementwise_apply(tensor, [](float x) {
+      return (x > 0) ? 1.0f : 0.0f;  // Defaults to 0, like TensorFlow does
+    });
+  }
+
+  /**
+   * @brief Apply the primitive of the ReLU function to the given tensor.
+
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the primitive of ReLU applied to each element.
+  */
+  Tensor<float> primitive(const Tensor<float>& t) const {
+    auto tensor = t;
+    return elementwise_apply(
+        tensor, [](float x) { return (x > 0) ? (x * x) / 2.0f : 0.0f; });
+  }
 };

--- a/src/include/mml_TensorFunction_TanH.hpp
+++ b/src/include/mml_TensorFunction_TanH.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cmath>
+#include "a_tensor_func.hpp"
+#include "mml_elementwise.hpp"
+
+/**
+ * @class mml_TensorFunction_Tanh
+ * @brief A class that implements a tensor function for the tanH function.
+ */
+class mml_TensorFunction_Tanh : public TensorFunction<float> {
+    public:
+
+    /**
+     * @brief Apply the tanH function to the given tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the tanH function applied to each element.
+    */
+    Tensor<float> func(const Tensor<float>& t) const{
+        auto tensor = t;
+        return elementwise_apply(tensor, [](float x) {
+            return std::tanh(x);
+        });
+        return tensor;
+    }
+    /**
+     * @brief Apply the derivative of the TanH function to the tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the derovative of tanH applied to each element.
+    */
+    Tensor<float> derivative(const Tensor<float>& t) const{
+        auto tensor = t;
+        return elementwise_apply(tensor, [](float x) {
+            float tanh_x = std::tanh(x);  // Compute the derivative of tanh(x)
+            return 1.0f - tanh_x * tanh_x;
+        });
+    }
+    /**
+     * @brief Apply the primitive of the tanH function to the given tensor.
+ 
+     * @param t The tensor to which the function will be applied.
+     * @return A new tensor with the primitive of tanH applied to each element.
+    */    
+    Tensor<float> primitive(const Tensor<float>& t) const{
+        auto tensor = t;
+        return elementwise_apply(tensor, [](float x) {
+            return std::log(std::cosh(x));  // Compute the integral of tanh(x)
+        });
+    }
+};

--- a/src/include/mml_TensorFunction_TanH.hpp
+++ b/src/include/mml_TensorFunction_TanH.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+
 #include "a_tensor_func.hpp"
 #include "mml_elementwise.hpp"
 
@@ -9,44 +10,43 @@
  * @brief A class that implements a tensor function for the tanH function.
  */
 class mml_TensorFunction_Tanh : public TensorFunction<float> {
-    public:
+ public:
+  /**
+   * @brief Apply the tanH function to the given tensor.
 
-    /**
-     * @brief Apply the tanH function to the given tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the tanH function applied to each element.
-    */
-    Tensor<float> func(const Tensor<float>& t) const{
-        auto tensor = t;
-        return elementwise_apply(tensor, [](float x) {
-            return std::tanh(x);
-        });
-        return tensor;
-    }
-    /**
-     * @brief Apply the derivative of the TanH function to the tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the derivative of tanH applied to each element.
-    */
-    Tensor<float> derivative(const Tensor<float>& t) const{
-        auto tensor = t;
-        return elementwise_apply(tensor, [](float x) {
-            float tanh_x = std::tanh(x);  // Compute the derivative of tanh(x)
-            return 1.0f - tanh_x * tanh_x;
-        });
-    }
-    /**
-     * @brief Apply the primitive of the tanH function to the given tensor.
- 
-     * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the primitive of tanH applied to each element.
-    */    
-    Tensor<float> primitive(const Tensor<float>& t) const{
-        auto tensor = t;
-        return elementwise_apply(tensor, [](float x) {
-            return std::log(std::cosh(x));  // Compute the integral of tanh(x)
-        });
-    }
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the tanH function applied to each element.
+  */
+  Tensor<float> func(const Tensor<float>& t) const {
+    auto tensor = t;
+    return elementwise_apply(tensor, [](float x) { return std::tanh(x); });
+    return tensor;
+  }
+
+  /**
+   * @brief Apply the derivative of the TanH function to the tensor.
+
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the derivative of tanH applied to each element.
+  */
+  Tensor<float> derivative(const Tensor<float>& t) const {
+    auto tensor = t;
+    return elementwise_apply(tensor, [](float x) {
+      float tanh_x = std::tanh(x);  // Compute the derivative of tanh(x)
+      return 1.0f - tanh_x * tanh_x;
+    });
+  }
+
+  /**
+   * @brief Apply the primitive of the tanH function to the given tensor.
+
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the primitive of tanH applied to each element.
+  */
+  Tensor<float> primitive(const Tensor<float>& t) const {
+    auto tensor = t;
+    return elementwise_apply(tensor, [](float x) {
+      return std::log(std::cosh(x));  // Compute the integral of tanh(x)
+    });
+  }
 };

--- a/src/include/mml_TensorFunction_TanH.hpp
+++ b/src/include/mml_TensorFunction_TanH.hpp
@@ -28,7 +28,7 @@ class mml_TensorFunction_Tanh : public TensorFunction<float> {
      * @brief Apply the derivative of the TanH function to the tensor.
  
      * @param t The tensor to which the function will be applied.
-     * @return A new tensor with the derovative of tanH applied to each element.
+     * @return A new tensor with the derivative of tanH applied to each element.
     */
     Tensor<float> derivative(const Tensor<float>& t) const{
         auto tensor = t;

--- a/src/include/mml_TensorFunction_TanH.hpp
+++ b/src/include/mml_TensorFunction_TanH.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <cmath>
-
-#include "a_tensor_func.hpp"
-#include "mml_elementwise.hpp"
+#include <modularml>
 
 /**
  * @class mml_TensorFunction_Tanh

--- a/src/include/mml_elementwise.hpp
+++ b/src/include/mml_elementwise.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "tensor.hpp"
+#include <modularml>
 
 /**
  * @brief Applies a given function element-wise to a tensor.

--- a/src/include/mml_elementwise.hpp
+++ b/src/include/mml_elementwise.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "tensor.hpp"
+
+/**
+ * @brief Applies a given function element-wise to a tensor.
+ * 
+ * This function iterates over each element in the given tensor and applies
+ * the provided function to each element, modifying the tensor in place.
+ * 
+ * @param t The tensor to which the function will be applied.
+ * @param f A pointer to the function that will be applied to each element of the tensor.
+ *          The function should take a float as input and return a float.
+ * @return A reference to the modified tensor.
+ */
+Tensor<float>& elementwise_apply(Tensor<float>& t, float (*f)(float)){
+    for (int i = 0; i < t.get_shape()[0]; i++) {
+        for (int j = 0; j < t.get_shape()[1]; j++) {
+        t[{i, j}] = f(t[{i, j}]);
+        }
+    }
+    return t;
+}

--- a/src/include/mml_elementwise.hpp
+++ b/src/include/mml_elementwise.hpp
@@ -14,6 +14,8 @@
  * @return A reference to the modified tensor.
  */
 Tensor<float>& elementwise_apply(Tensor<float>& t, float (*f)(float)){
+    // This function can be made way more efficent by the use of multi-threading
+    // I intend on making that an improvement in the future
     for (int i = 0; i < t.get_shape()[0]; i++) {
         for (int j = 0; j < t.get_shape()[1]; j++) {
         t[{i, j}] = f(t[{i, j}]);

--- a/src/include/mml_elementwise.hpp
+++ b/src/include/mml_elementwise.hpp
@@ -4,22 +4,22 @@
 
 /**
  * @brief Applies a given function element-wise to a tensor.
- * 
+ *
  * This function iterates over each element in the given tensor and applies
  * the provided function to each element, modifying the tensor in place.
- * 
+ *
  * @param t The tensor to which the function will be applied.
- * @param f A pointer to the function that will be applied to each element of the tensor.
- *          The function should take a float as input and return a float.
+ * @param f A pointer to the function that will be applied to each element of
+ * the tensor. The function should take a float as input and return a float.
  * @return A reference to the modified tensor.
  */
-Tensor<float>& elementwise_apply(Tensor<float>& t, float (*f)(float)){
-    // This function can be made way more efficent by the use of multi-threading
-    // I intend on making that an improvement in the future
-    for (int i = 0; i < t.get_shape()[0]; i++) {
-        for (int j = 0; j < t.get_shape()[1]; j++) {
-        t[{i, j}] = f(t[{i, j}]);
-        }
+Tensor<float>& elementwise_apply(Tensor<float>& t, float (*f)(float)) {
+  // This function can be made way more efficent by the use of multi-threading
+  // I intend on making that an improvement in the future
+  for (int i = 0; i < t.get_shape()[0]; i++) {
+    for (int j = 0; j < t.get_shape()[1]; j++) {
+      t[{i, j}] = f(t[{i, j}]);
     }
-    return t;
+  }
+  return t;
 }

--- a/src/include/modularml
+++ b/src/include/modularml
@@ -11,3 +11,6 @@
 #include "mml_tensors.hpp"
 #include "mml_vector.hpp"
 #include "tensor.hpp"
+#include "mml_elementwise.hpp"
+#include "mml_TensorFunction_ReLU.hpp"
+#include "mml_TensorFunction_TanH.hpp"

--- a/tests/test_mml_TensorFunction_ReLU.cpp
+++ b/tests/test_mml_TensorFunction_ReLU.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+#include <iostream>
+#include <modularml>
+#include <numeric>
+#include <vector>
+
+#define assert_msg(name, condition)                         \
+  if (!(condition)) {                                       \
+    std::cerr << "Assertion failed: " << name << std::endl; \
+  }                                                         \
+  assert(condition);                                        \
+  std::cout << name << ": " << (condition ? "Passed" : "Failed") << std::endl;
+
+/**
+ * @file test_mml_TensorFunction_ReLU.cpp
+ * @brief Unit tests for the ReLUFunction class.
+ *
+ * This file contains test cases that validate the correctness of the
+ * ReLUFunction class by checking its `func`, `derivative`, and `primitive`
+ * methods using predefined tensors.
+ *
+ * The tests verify that:
+ * - `func()` correctly applies ReLU to each tensor element (max(0, x)).
+ * - `derivative()` correctly computes the derivative of ReLU (1 for x > 0, else
+ * 0).
+ * - `primitive()` correctly computes the integral of ReLU (0.5 * max(0, x)^2).
+ *
+ * Each test outputs a success/failure message using `assert_msg` and ensures
+ * correct behavior of the ReLUFunction implementation.
+ */
+int main() {
+  // Define the ReLU function class to test
+  mml_TensorFunction_ReLU ReLU_func;
+  /**
+   * @brief Tensor to test and compare the operations on.
+   */
+  Tensor<float> t1 = tensor_mll({3, 3}, {-1, 0, 1, -2, 2, -3, 3, 4, -4});
+
+  /**
+   * @brief Expected Tensor after the ReLU function is applied to each element.
+   */
+  Tensor<float> expected_func = tensor_mll(
+      {3, 3}, {0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 3.0f, 4.0f, 0.0f});
+
+  /**
+   * @brief Expected Tensor after the derivative of the ReLU function is applied
+   * to each element.
+   */
+  Tensor<float> expected_derivative = tensor_mll(
+      {3, 3}, {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f});
+
+  /**
+   * @brief Expected Tensor after the primitive of the ReLU function is applied
+   * to each element.
+   */
+  Tensor<float> expected_primitive = tensor_mll(
+      {3, 3}, {0.0f, 0.0f, 0.5f, 0.0f, 2.0f, 0.0f, 4.5f, 8.0f, 0.0f});
+
+  // Test applying ReLU
+  assert_msg("ReLUFunction func test", ReLU_func.func(t1) == expected_func);
+  // Test applying the derivative of ReLU
+  assert_msg("ReLUFunction derivative test",
+             ReLU_func.derivative(t1) == expected_derivative);
+  // Test applying the primitive of ReLU
+  assert_msg("ReLUFunction primitive test",
+             ReLU_func.primitive(t1) == expected_primitive);
+
+  std::cout << "All ReLUFunction tests completed!" << std::endl;
+  return 0;
+}

--- a/tests/test_mml_TensorFunction_Tanh.cpp
+++ b/tests/test_mml_TensorFunction_Tanh.cpp
@@ -3,8 +3,8 @@
 #include <modularml>
 #include <numeric>
 #include <vector>
+#include <modularml>
 
-#include "mml_TensorFunction_TanH.hpp"
 
 #define assert_msg(name, condition)                         \
   if (!(condition)) {                                       \
@@ -82,9 +82,12 @@ int main() {
                           static_cast<float>(std::log(std::cosh(4))),
                           static_cast<float>(std::log(std::cosh(-4)))});
 
+  // Test applying tanH
   assert_msg("TanhFunction func test", tanh_func.func(t1) == expected_func);
+  // Test applying the derivative of tanH
   assert_msg("TanhFunction derivative test",
              tanh_func.derivative(t1) == expected_derivative);
+  // Test applying the primitive of tanH
   assert_msg("TanhFunction primitive test",
              tanh_func.primitive(t1) == expected_primitive);
 

--- a/tests/test_mml_TensorFunction_Tanh.cpp
+++ b/tests/test_mml_TensorFunction_Tanh.cpp
@@ -4,6 +4,7 @@
 #include <numeric>
 #include <random>
 #include <vector>
+
 #include "mml_TensorFunction_TanH.hpp"
 
 #define assert_msg(name, condition)                         \
@@ -27,51 +28,62 @@ Vec<float> random_vec_f(int size, float low, float max, int seed = 0) {
  * @file test_mml_TensorFunction_Tanh.cpp
  * @brief Unit tests for the TanhFunction class.
  *
- * This file contains test cases that validate the correctness of the TanhFunction
- * class by checking its `func`, `derivative`, and `primitive` methods using 
- * predefined tensors and mathematical expectations.
+ * This file contains test cases that validate the correctness of the
+ * TanhFunction class by checking its `func`, `derivative`, and `primitive`
+ * methods using predefined tensors and mathematical expectations.
  *
  * The tests verify that:
  * - `func()` correctly applies tanh to each tensor element.
  * - `derivative()` correctly computes the derivative of tanh (1 - tanh^2(x)).
  * - `primitive()` correctly computes the integral of tanh (ln|cosh(x)|).
  *
- * Each test outputs a success/failure message using `assert_msg` and ensures 
+ * Each test outputs a success/failure message using `assert_msg` and ensures
  * correct behavior of the TanhFunction implementation.
  */
 int main() {
-  //replace any implementation of a TensorFunction class for a tanH function here:
+  // replace any implementation of a TensorFunction class for a tanH function
+  // here:
   mml_TensorFunction_Tanh tanh_func;
 
   Tensor<float> t1 = tensor_mll({3, 3}, {-1, 0, 1, -2, 2, -3, 3, 4, -4});
 
-  Tensor<float> expected_func = tensor_mll({3, 3}, {
-      static_cast<float>(std::tanh(-1)), static_cast<float>(std::tanh(0)), static_cast<float>(std::tanh(1)),
-      static_cast<float>(std::tanh(-2)), static_cast<float>(std::tanh(2)), static_cast<float>(std::tanh(-3)),
-      static_cast<float>(std::tanh(3)), static_cast<float>(std::tanh(4)), static_cast<float>(std::tanh(-4))
-  });
+  Tensor<float> expected_func = tensor_mll(
+      {3, 3},
+      {static_cast<float>(std::tanh(-1)), static_cast<float>(std::tanh(0)),
+       static_cast<float>(std::tanh(1)), static_cast<float>(std::tanh(-2)),
+       static_cast<float>(std::tanh(2)), static_cast<float>(std::tanh(-3)),
+       static_cast<float>(std::tanh(3)), static_cast<float>(std::tanh(4)),
+       static_cast<float>(std::tanh(-4))});
 
-  Tensor<float> expected_derivative = tensor_mll({3, 3}, {
-      static_cast<float>(1 - std::tanh(-1) * std::tanh(-1)),
-      static_cast<float>(1 - std::tanh(0) * std::tanh(0)),
-      static_cast<float>(1 - std::tanh(1) * std::tanh(1)),
-      static_cast<float>(1 - std::tanh(-2) * std::tanh(-2)),
-      static_cast<float>(1 - std::tanh(2) * std::tanh(2)),
-      static_cast<float>(1 - std::tanh(-3) * std::tanh(-3)),
-      static_cast<float>(1 - std::tanh(3) * std::tanh(3)),
-      static_cast<float>(1 - std::tanh(4) * std::tanh(4)),
-      static_cast<float>(1 - std::tanh(-4) * std::tanh(-4)),
-  });
+  Tensor<float> expected_derivative = tensor_mll(
+      {3, 3}, {
+                  static_cast<float>(1 - std::tanh(-1) * std::tanh(-1)),
+                  static_cast<float>(1 - std::tanh(0) * std::tanh(0)),
+                  static_cast<float>(1 - std::tanh(1) * std::tanh(1)),
+                  static_cast<float>(1 - std::tanh(-2) * std::tanh(-2)),
+                  static_cast<float>(1 - std::tanh(2) * std::tanh(2)),
+                  static_cast<float>(1 - std::tanh(-3) * std::tanh(-3)),
+                  static_cast<float>(1 - std::tanh(3) * std::tanh(3)),
+                  static_cast<float>(1 - std::tanh(4) * std::tanh(4)),
+                  static_cast<float>(1 - std::tanh(-4) * std::tanh(-4)),
+              });
 
-  Tensor<float> expected_primitive = tensor_mll({3, 3}, {
-      static_cast<float>(std::log(std::cosh(-1))), static_cast<float>(std::log(std::cosh(0))), static_cast<float>(std::log(std::cosh(1))),
-      static_cast<float>(std::log(std::cosh(-2))), static_cast<float>(std::log(std::cosh(2))), static_cast<float>(std::log(std::cosh(-3))),
-      static_cast<float>(std::log(std::cosh(3))), static_cast<float>(std::log(std::cosh(4))), static_cast<float>(std::log(std::cosh(-4)))
-  });
+  Tensor<float> expected_primitive =
+      tensor_mll({3, 3}, {static_cast<float>(std::log(std::cosh(-1))),
+                          static_cast<float>(std::log(std::cosh(0))),
+                          static_cast<float>(std::log(std::cosh(1))),
+                          static_cast<float>(std::log(std::cosh(-2))),
+                          static_cast<float>(std::log(std::cosh(2))),
+                          static_cast<float>(std::log(std::cosh(-3))),
+                          static_cast<float>(std::log(std::cosh(3))),
+                          static_cast<float>(std::log(std::cosh(4))),
+                          static_cast<float>(std::log(std::cosh(-4)))});
 
   assert_msg("TanhFunction func test", tanh_func.func(t1) == expected_func);
-  assert_msg("TanhFunction derivative test", tanh_func.derivative(t1) == expected_derivative);
-  assert_msg("TanhFunction primitive test", tanh_func.primitive(t1) == expected_primitive);
+  assert_msg("TanhFunction derivative test",
+             tanh_func.derivative(t1) == expected_derivative);
+  assert_msg("TanhFunction primitive test",
+             tanh_func.primitive(t1) == expected_primitive);
 
   std::cout << "All TanhFunction tests completed!" << std::endl;
   return 0;

--- a/tests/test_mml_TensorFunction_Tanh.cpp
+++ b/tests/test_mml_TensorFunction_Tanh.cpp
@@ -34,8 +34,14 @@ int main() {
   // here:
   mml_TensorFunction_Tanh tanh_func;
 
+  /**
+   * @brief Tensor to test and compare the operations on.
+   */
   Tensor<float> t1 = tensor_mll({3, 3}, {-1, 0, 1, -2, 2, -3, 3, 4, -4});
 
+  /**
+   * @brief Expected Tensor after the tanH function is applied to each element.
+   */
   Tensor<float> expected_func = tensor_mll(
       {3, 3},
       {static_cast<float>(std::tanh(-1)), static_cast<float>(std::tanh(0)),
@@ -44,6 +50,10 @@ int main() {
        static_cast<float>(std::tanh(3)), static_cast<float>(std::tanh(4)),
        static_cast<float>(std::tanh(-4))});
 
+  /**
+   * @brief Expected Tensor after the derivative of the tanH function is applied
+   * to each element.
+   */
   Tensor<float> expected_derivative = tensor_mll(
       {3, 3}, {
                   static_cast<float>(1 - std::tanh(-1) * std::tanh(-1)),
@@ -57,6 +67,10 @@ int main() {
                   static_cast<float>(1 - std::tanh(-4) * std::tanh(-4)),
               });
 
+  /**
+   * @brief Expected Tensor after the primitive of the tanH function is applied
+   * to each element.
+   */
   Tensor<float> expected_primitive =
       tensor_mll({3, 3}, {static_cast<float>(std::log(std::cosh(-1))),
                           static_cast<float>(std::log(std::cosh(0))),

--- a/tests/test_mml_TensorFunction_Tanh.cpp
+++ b/tests/test_mml_TensorFunction_Tanh.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <iostream>
+#include <modularml>
+#include <numeric>
+#include <random>
+#include <vector>
+#include "mml_TensorFunction_TanH.hpp"
+
+#define assert_msg(name, condition)                         \
+  if (!(condition)) {                                       \
+    std::cerr << "Assertion failed: " << name << std::endl; \
+  }                                                         \
+  assert(condition);                                        \
+  std::cout << name << ": " << (condition ? "Passed" : "Failed") << std::endl;
+
+Vec<float> random_vec_f(int size, float low, float max, int seed = 0) {
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<float> dist(low, max);
+  Vec<float> v(size);
+  for (int i = 0; i < size; i++) {
+    v[i] = dist(gen);
+  }
+  return v;
+}
+
+/**
+ * @file test_mml_TensorFunction_Tanh.cpp
+ * @brief Unit tests for the TanhFunction class.
+ *
+ * This file contains test cases that validate the correctness of the TanhFunction
+ * class by checking its `func`, `derivative`, and `primitive` methods using 
+ * predefined tensors and mathematical expectations.
+ *
+ * The tests verify that:
+ * - `func()` correctly applies tanh to each tensor element.
+ * - `derivative()` correctly computes the derivative of tanh (1 - tanh^2(x)).
+ * - `primitive()` correctly computes the integral of tanh (ln|cosh(x)|).
+ *
+ * Each test outputs a success/failure message using `assert_msg` and ensures 
+ * correct behavior of the TanhFunction implementation.
+ */
+int main() {
+  //replace any implementation of a TensorFunction class for a tanH function here:
+  mml_TensorFunction_Tanh tanh_func;
+
+  Tensor<float> t1 = tensor_mll({3, 3}, {-1, 0, 1, -2, 2, -3, 3, 4, -4});
+
+  Tensor<float> expected_func = tensor_mll({3, 3}, {
+      static_cast<float>(std::tanh(-1)), static_cast<float>(std::tanh(0)), static_cast<float>(std::tanh(1)),
+      static_cast<float>(std::tanh(-2)), static_cast<float>(std::tanh(2)), static_cast<float>(std::tanh(-3)),
+      static_cast<float>(std::tanh(3)), static_cast<float>(std::tanh(4)), static_cast<float>(std::tanh(-4))
+  });
+
+  Tensor<float> expected_derivative = tensor_mll({3, 3}, {
+      static_cast<float>(1 - std::tanh(-1) * std::tanh(-1)),
+      static_cast<float>(1 - std::tanh(0) * std::tanh(0)),
+      static_cast<float>(1 - std::tanh(1) * std::tanh(1)),
+      static_cast<float>(1 - std::tanh(-2) * std::tanh(-2)),
+      static_cast<float>(1 - std::tanh(2) * std::tanh(2)),
+      static_cast<float>(1 - std::tanh(-3) * std::tanh(-3)),
+      static_cast<float>(1 - std::tanh(3) * std::tanh(3)),
+      static_cast<float>(1 - std::tanh(4) * std::tanh(4)),
+      static_cast<float>(1 - std::tanh(-4) * std::tanh(-4)),
+  });
+
+  Tensor<float> expected_primitive = tensor_mll({3, 3}, {
+      static_cast<float>(std::log(std::cosh(-1))), static_cast<float>(std::log(std::cosh(0))), static_cast<float>(std::log(std::cosh(1))),
+      static_cast<float>(std::log(std::cosh(-2))), static_cast<float>(std::log(std::cosh(2))), static_cast<float>(std::log(std::cosh(-3))),
+      static_cast<float>(std::log(std::cosh(3))), static_cast<float>(std::log(std::cosh(4))), static_cast<float>(std::log(std::cosh(-4)))
+  });
+
+  assert_msg("TanhFunction func test", tanh_func.func(t1) == expected_func);
+  assert_msg("TanhFunction derivative test", tanh_func.derivative(t1) == expected_derivative);
+  assert_msg("TanhFunction primitive test", tanh_func.primitive(t1) == expected_primitive);
+
+  std::cout << "All TanhFunction tests completed!" << std::endl;
+  return 0;
+}

--- a/tests/test_mml_TensorFunction_Tanh.cpp
+++ b/tests/test_mml_TensorFunction_Tanh.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <modularml>
 #include <numeric>
-#include <random>
 #include <vector>
 
 #include "mml_TensorFunction_TanH.hpp"
@@ -13,16 +12,6 @@
   }                                                         \
   assert(condition);                                        \
   std::cout << name << ": " << (condition ? "Passed" : "Failed") << std::endl;
-
-Vec<float> random_vec_f(int size, float low, float max, int seed = 0) {
-  std::mt19937 gen(seed);
-  std::uniform_real_distribution<float> dist(low, max);
-  Vec<float> v(size);
-  for (int i = 0; i < size; i++) {
-    v[i] = dist(gen);
-  }
-  return v;
-}
 
 /**
  * @file test_mml_TensorFunction_Tanh.cpp

--- a/tests/test_mml_elementwise.cpp
+++ b/tests/test_mml_elementwise.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+#include <iostream>
+#include <modularml>
+#include <vector>
+#include "mml_elementwise.hpp"
+
+#define assert_msg(name, condition)                         \
+    if (!(condition)) {                                       \
+        std::cerr << "Assertion failed: " << name << std::endl; \
+    }                                                         \
+    assert(condition);                                        \
+    std::cout << name << ": " << (condition ? "Passed" : "Failed") << std::endl;
+
+float square(float x) {
+    return x * x;
+}
+
+int main() {
+    Tensor<float> t1 = tensor_mll({3, 3}, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+    Tensor<float> t2 = tensor_mll({3, 3}, {1, 4, 9, 16, 25, 36, 49, 64, 81});
+
+    // Test elementwise_apply function
+    elementwise_apply(t1, square);
+    assert_msg("Elementwise apply test", t1 == t2);
+
+    std::cout << "All tests completed!" << std::endl;
+
+    return 0;
+}

--- a/tests/test_mml_elementwise.cpp
+++ b/tests/test_mml_elementwise.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <modularml>
 #include <vector>
-#include "mml_elementwise.hpp"
+#include <modularml>
 
 #define assert_msg(name, condition)                         \
     if (!(condition)) {                                       \


### PR DESCRIPTION

### Description
Added two new classes that derive from the abbreviated class [a_tensor_func.hpp](https://github.com/willayy/modularml/blob/bc3d833c4c7b5d4f811b69c5843d91f53019cecb/src/include/a_tensor_func.hpp):

`mml_TensorFunction_ReLU.hpp` & `mml_TensorFunction_TanH.hpp`.

Added a header-only utility called `mml_elementwise.hpp` that the two classes utilise.

Added tests for the two classes, these tests compare the results against predefined tensors.

Added a test for `mml_elementwise.hpp`

### Issue
Implements #53 #56 #43