### PR TITLE
Add dependency installation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ OS := $(shell uname -s)
 # There are slight variations in the dependencies between operating systems.
 ifeq ($(OS), Linux)
 	PKG_MANAGER := sudo apt-get install -y
-	DEPENDENCIES := cmake g++ make gcovr doxygen
+	DEPENDENCIES := cmake g++ make python3-pip graphviz gcovr doxygen
 endif
 
 ifeq ($(OS), Darwin) # MacOS
 	PKG_MANAGER := brew install
-	DEPENDENCIES := cmake g++ make gcovr doxygen
+	DEPENDENCIES := cmake g++ make graphviz gcovr doxygen
 endif
 
 .PHONY: all config build run clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
 BUILD_DIR := build
 
 CMAKE := $(shell which cmake)
+OS := $(shell uname -s)
+
+# Detect which os the user has and set the package manager and dependencies accordingly
+# There are slight variations in the dependencies between operating systems.
+ifeq ($(OS), Linux)
+	PKG_MANAGER := sudo apt-get install -y
+	DEPENDENCIES := cmake g++ make gcovr doxygen
+endif
+
+ifeq ($(OS), Darwin) # MacOS
+	PKG_MANAGER := brew install
+	DEPENDENCIES := cmake g++ make gcovr doxygen
+endif
 
 .PHONY: all config build run clean
 
@@ -16,8 +29,11 @@ build:
 
 # Will install dependencies
 install:
-	@echo "Not set up currently..."
-
+	@echo "Detected OS: $(OS)"
+	@echo "Installing dependencies..."
+	@$(PKG_MANAGER) $(DEPENDENCIES)
+	@pip install -r requirements.txt
+	@echo "Installation complete!"
 
 run:
 	@echo "Running main program...\n"


### PR DESCRIPTION
### Description
Made and addition to the root Makefile to be able to install all needed dependencies by simply running `make install` in the terminal. I know that i have missed one dependency which one of our main dependencies rely on if I am not mistaken, when that dependency is identified it will get added to the process.

Edit: I tried in a fresh environment to build the project and identified the missing dependencies and added them to the Makefile.

### Issue
Closes #71 