### PR TITLE
Add Tests for SoftMax,fix softmax mml, fix issue with compute_offsets() in tensor.hpp

### DIFF
--- a/src/include/mml_TensorFunction_SoftMax.hpp
+++ b/src/include/mml_TensorFunction_SoftMax.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "mml_elementwise.hpp"
+#include "tensor.hpp"
+#include <cmath>
+
+/**
+ * @class mml_TensorFunction_SoftMax
+ * @brief A class that implements a tensor function for the SoftMax function.
+ */
+class mml_TensorFunction_SoftMax : public TensorFunction<float> {
+private:
+  mutable mml_elementwise<float>
+      elementwise; // Determines what version of elementwise to use
+
+public:
+  /**
+   * @brief Apply the SoftMax function to the given tensor along the specified
+   * axis.
+   *
+   * @param t The tensor to which the function will be applied.
+   * @param axis The axis along which to apply SoftMax. Default is -1 (last
+   * axis).
+   * @return A new tensor with SoftMax applied.
+   */
+  Tensor<float> func(const Tensor<float> &t, int axis = -1) const {
+    auto shape = t.get_shape();
+    if (axis < 0)
+      axis += shape.size(); // Adjust for negative axis
+
+    if (axis < 0 || axis >= static_cast<int>(shape.size())) {
+      throw std::out_of_range("Invalid axis for SoftMax function");
+    }
+
+    Tensor<float> output = t; // Copy input tensor for output
+    int axis_size = shape[axis];
+
+    // Compute SoftMax along the specified axis
+    for (int i = 0; i < t.get_size() / axis_size; ++i) {
+      float max_val = -std::numeric_limits<float>::infinity();
+      for (int j = 0; j < axis_size; ++j) {
+        max_val = std::max(max_val, t[{i, j}]);
+      }
+
+      float sum = 0;
+      for (int j = 0; j < axis_size; ++j) {
+        output[{i, j}] = std::exp(t[{i, j}] - max_val);
+        sum += output[{i, j}];
+      }
+
+      for (int j = 0; j < axis_size; ++j) {
+        output[{i, j}] /= sum;
+      }
+    }
+    return output;
+  }
+
+  /**
+   * @brief Apply the derivative of the SoftMax function to the tensor.
+   *
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the derivative of SoftMax applied.
+   */
+  Tensor<float> derivative(const Tensor<float> &t) const {
+    return elementwise.apply(t, [](float x) { return x * (1.0f - x); });
+  }
+
+  /**
+   * @brief Apply the primitive of the SoftMax function to the given tensor.
+   *
+   * @param t The tensor to which the function will be applied.
+   * @return A new tensor with the primitive of SoftMax applied.
+   */
+  Tensor<float> primitive(const Tensor<float> &t) const {
+    return elementwise.apply(t, [](float x) { return std::log(x); });
+  }
+};

--- a/src/include/mml_TensorFunction_SoftMax.hpp
+++ b/src/include/mml_TensorFunction_SoftMax.hpp
@@ -1,77 +1,109 @@
 #pragma once
 
-#include "mml_elementwise.hpp"
 #include "tensor.hpp"
+#include "a_tensor_func.hpp"
+#include "mml_tensors.hpp"
 #include <cmath>
+#include <limits>
 
 /**
  * @class mml_TensorFunction_SoftMax
- * @brief A class that implements a tensor function for the SoftMax function.
+ * @brief Implements the SoftMax activation function for tensors.
  */
 class mml_TensorFunction_SoftMax : public TensorFunction<float> {
 private:
-  mutable mml_elementwise<float>
-      elementwise; // Determines what version of elementwise to use
+    int axis; // Axis to apply SoftMax on
 
 public:
-  /**
-   * @brief Apply the SoftMax function to the given tensor along the specified
-   * axis.
-   *
-   * @param t The tensor to which the function will be applied.
-   * @param axis The axis along which to apply SoftMax. Default is -1 (last
-   * axis).
-   * @return A new tensor with SoftMax applied.
-   */
-  Tensor<float> func(const Tensor<float> &t, int axis = -1) const {
-    auto shape = t.get_shape();
-    if (axis < 0)
-      axis += shape.size(); // Adjust for negative axis
+    /**
+     * @brief Constructor
+     * @param axis The axis along which to apply SoftMax (default -1 = last axis)
+     */
+    explicit mml_TensorFunction_SoftMax(int axis = -1) : axis(axis) {}
 
-    if (axis < 0 || axis >= static_cast<int>(shape.size())) {
-      throw std::out_of_range("Invalid axis for SoftMax function");
+    /**
+     * @brief Apply SoftMax to a tensor along the specified axis.
+     */
+    Tensor<float> func(const Tensor<float>& t) const override {
+        auto shape = t.get_shape();
+        int adjusted_axis = (axis < 0) ? (shape.size() + axis) : axis;
+
+        if (adjusted_axis < 0 || adjusted_axis >= static_cast<int>(shape.size())) {
+            throw std::out_of_range("Invalid axis for SoftMax function");
+        }
+
+        Tensor<float> output(t.get_shape()); // Zero-initialized tensor
+        int axis_size = shape[adjusted_axis];
+        int batch_size = t.get_size() / axis_size; // Number of rows
+
+        // **1D SoftMax**
+        if (shape.size() == 1) { 
+            float max_val = t.max_element();
+            float sum = 0.0f;
+
+            // Compute exponentials and sum
+            for (int i = 0; i < t.get_size(); i++) {
+                output[i] = std::exp(t[i] - max_val);
+                sum += output[i];
+            }
+
+            // Normalize
+            for (int i = 0; i < t.get_size(); i++) {
+                output[i] /= sum;
+            }
+        } 
+        // **2D Row-Wise SoftMax**
+        else { 
+            for (int i = 0; i < batch_size; ++i) {
+                float max_val = -std::numeric_limits<float>::infinity();
+                float sum = 0.0f;
+
+                // Step 1: Find max value in row
+                for (int j = 0; j < axis_size; ++j) {
+                    max_val = std::max(max_val, t[{i, j}]);
+                }
+
+                // Step 2: Compute exponentials & sum
+                for (int j = 0; j < axis_size; ++j) {
+                    output[{i, j}] = std::exp(t[{i, j}] - max_val);
+                    sum += output[{i, j}];
+                }
+
+                // Step 3: Normalize row-wise
+                for (int j = 0; j < axis_size; ++j) {
+                    output[{i, j}] /= sum;
+                }
+            }
+        }
+
+        return output;
     }
 
-    Tensor<float> output = t; // Copy input tensor for output
-    int axis_size = shape[axis];
+    /**
+     * @brief Compute the derivative of SoftMax.
+     */
+    Tensor<float> derivative(const Tensor<float>& t) const override {
+        Tensor<float> softmax_t = func(t); // Get SoftMax output
+        Tensor<float> jacobian({t.get_size(), t.get_size()});
 
-    // Compute SoftMax along the specified axis
-    for (int i = 0; i < t.get_size() / axis_size; ++i) {
-      float max_val = -std::numeric_limits<float>::infinity();
-      for (int j = 0; j < axis_size; ++j) {
-        max_val = std::max(max_val, t[{i, j}]);
-      }
-
-      float sum = 0;
-      for (int j = 0; j < axis_size; ++j) {
-        output[{i, j}] = std::exp(t[{i, j}] - max_val);
-        sum += output[{i, j}];
-      }
-
-      for (int j = 0; j < axis_size; ++j) {
-        output[{i, j}] /= sum;
-      }
+        for (int i = 0; i < t.get_size(); ++i) {
+            for (int j = 0; j < t.get_size(); ++j) {
+                if (i == j) {
+                    jacobian[{i, j}] = softmax_t[i] * (1 - softmax_t[i]);
+                } else {
+                    jacobian[{i, j}] = -softmax_t[i] * softmax_t[j];
+                }
+            }
+        }
+        return jacobian;
     }
-    return output;
-  }
 
-  /**
-   * @brief Apply the derivative of the SoftMax function to the tensor.
-   *
-   * @param t The tensor to which the function will be applied.
-   * @return A new tensor with the derivative of SoftMax applied.
-   */
-  Tensor<float> derivative(const Tensor<float> &t) const {
-    return elementwise.apply(t, [](float x) { return x * (1.0f - x); });
-  }
-
-  /**
-   * @brief Apply the primitive of the SoftMax function to the given tensor.
-   *
-   * @param t The tensor to which the function will be applied.
-   * @return A new tensor with the primitive of SoftMax applied.
-   */
-  Tensor<float> primitive(const Tensor<float> &t) const {
-    return elementwise.apply(t, [](float x) { return std::log(x); });
-  }
+    /**
+     * @brief Compute the primitive function (log of SoftMax).
+     */
+    Tensor<float> primitive(const Tensor<float>& t) const override {
+        Tensor<float> result = t;
+        result.apply_function([](float x) { return std::log(x); }); // Use apply_function()
+        return result;
+    }
 };

--- a/src/include/modularml
+++ b/src/include/modularml
@@ -12,6 +12,7 @@
 #include "mml_TensorFunction_ReLU.hpp"
 #include "mml_TensorFunction_Swish.hpp"
 #include "mml_TensorFunction_TanH.hpp"
+#include "mml_TensorFunction_SoftMax.hpp"
 #include "mml_arithmetic.hpp"
 #include "mml_elementwise.hpp"
 #include "mml_gemm.hpp"

--- a/tests/test_mml_TensorFunction_SoftMax.cpp
+++ b/tests/test_mml_TensorFunction_SoftMax.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include <modularml>
+#include <cmath>
+
+/**
+ * @brief Test SoftMax function with a 1D tensor.
+ */
+TEST(mml_TensorFunction_SoftMax, OneDimensionalTensor) {
+    mml_TensorFunction_SoftMax softmax; // Default: last axis (-1)
+
+    // Define input tensor
+    Tensor<float> t1 = tensor_mml<float>({3}, {1.0f, 2.0f, 3.0f});
+    
+    // Compute expected SoftMax values
+    float max_val = 3.0f;
+    float exp1 = std::exp(1.0f - max_val);
+    float exp2 = std::exp(2.0f - max_val);
+    float exp3 = std::exp(3.0f - max_val);
+    float sum = exp1 + exp2 + exp3;
+
+    Tensor<float> expected = tensor_mml<float>({3}, {exp1 / sum, exp2 / sum, exp3 / sum});
+
+    // Apply SoftMax
+    Tensor<float> result = softmax.func(t1);
+
+    // Validate output
+    ASSERT_TRUE(tensors_are_close(result, expected));
+}
+
+/**
+ * @brief Test SoftMax function with a 2D tensor.
+ */
+TEST(mml_TensorFunction_SoftMax, TwoDimensionalTensor) {
+    mml_TensorFunction_SoftMax softmax(-1); // Apply along last axis
+
+    // Define input tensor
+    Tensor<float> t2 = tensor_mml<float>({2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+    
+    // Compute expected SoftMax values row-wise
+    float max_val_row1 = 3.0f;
+    float exp1 = std::exp(1.0f - max_val_row1);
+    float exp2 = std::exp(2.0f - max_val_row1);
+    float exp3 = std::exp(3.0f - max_val_row1);
+    float sum1 = exp1 + exp2 + exp3;
+
+    float max_val_row2 = 6.0f;
+    float exp4 = std::exp(4.0f - max_val_row2);
+    float exp5 = std::exp(5.0f - max_val_row2);
+    float exp6 = std::exp(6.0f - max_val_row2);
+    float sum2 = exp4 + exp5 + exp6;
+
+    Tensor<float> expected = tensor_mml<float>({2, 3}, {
+        exp1 / sum1, exp2 / sum1, exp3 / sum1,
+        exp4 / sum2, exp5 / sum2, exp6 / sum2
+    });
+
+    // Apply SoftMax
+    Tensor<float> result = softmax.func(t2);
+
+    // Validate output
+    ASSERT_TRUE(tensors_are_close(result, expected));
+}


### PR DESCRIPTION
### Description
Fixed SoftMax_mml to now compute correctly and added test file to test that SoftMax produce correct output. Also fixed an issue with compute_offsets() which resulted in offsets to be incorrectly calculated which in my tests resulted in 2 indexes being the same in memory, example as i assigned values 
expected:
`[1,2,3]`
`[4,5,6]`
actual:
`[1,2,3]`
`[3,5,6]`
and even as i were assinging row wise it would assign the [1,0] at the same time [0,2] was assigned hinting that they were the same in memory, aswell as when later [1,0] were assigned it overwrote the [0,2] aswell.

Tests passes with correct output, currently 1D and 2D, planning on adding N-D for better flexibility, does currently not use the "a_arithmetic_module.hpp", thinking of implementing it.
### Issue
Closes #[58]