### PR TITLE
Add Feature: Conv Node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ run:
 	@echo "Running main program...\n"
 	@cd ./build/bin && ./modularml
 
-test:
+test: all
 	@echo "Running tests...\n"
 	@cd ./build && ctest --output-on-failure
 

--- a/src/conv_node.tpp
+++ b/src/conv_node.tpp
@@ -1,0 +1,268 @@
+#include "conv_node.hpp"
+
+template <typename T>
+ConvNode<T>::ConvNode(shared_ptr<AbstractTensor> X,
+                      shared_ptr<AbstractTensor> W,
+                      shared_ptr<AbstractTensor> Y,
+                      array_mml<int> dilations,
+                      array_mml<int> padding,
+                      array_mml<int> kernel_shape,
+                      array_mml<int> stride,
+                      optional<shared_ptr<AbstractTensor>> B,
+                      int group)
+    : X(X), W(W), B(B), Y(Y), dilations(dilations), padding(padding), kernel_shape(kernel_shape), stride(stride) {
+    kernel_height = W->get_shape()[2];
+    kernel_width = W->get_shape()[3];
+    batch_size = X->get_shape()[0];
+    in_channels = X->get_shape()[1];
+    in_height = X->get_shape()[2];
+    in_width = X->get_shape()[3];
+    out_channels = W->get_shape()[0];
+}
+
+template <typename T>
+void ConvNode<T>::forward() {
+    validate_inputs();
+
+    // Create a copy of the input
+    auto input_copy = X->copy();
+
+    // Begin by flipping the weight kernel
+    flip_kernel();
+
+    auto im2col_output_shape = array_mml<int>({get_in_channels() * get_kernel_height() * get_kernel_width(),
+                                               get_batch_size() * get_out_height() * get_out_width()});
+
+    auto im2col_output = make_shared<Tensor_mml<T>>(im2col_output_shape);
+
+    im2col(input_copy, im2col_output);
+
+    // Flatten the weight tensor to prepare for GEMM
+    int flattened_size = get_in_channels() * get_kernel_height() * get_kernel_width();
+    W->reshape({get_out_channels(), flattened_size});
+
+    // Prepare the result tensor
+    array_mml<int> result_shape({W->get_shape()[0], im2col_output->get_shape()[1]});
+    auto result_ptr = make_shared<Tensor_mml<T>>(result_shape);
+
+    shared_ptr<GemmModule<T>> gemm = make_shared<Gemm_mml<T>>();
+    gemm->gemm_inner_product(
+        0, 0,
+        W->get_shape()[0], im2col_output->get_shape()[1], W->get_shape()[1],
+        1.0f,
+        W, W->get_shape()[1],
+        im2col_output, im2col_output->get_shape()[1],
+        0.0f,
+        result_ptr, result_ptr->get_shape()[1]);
+
+    // Reshape the flattened result
+    result_ptr->reshape({get_batch_size(), get_out_channels(), get_out_height(), get_out_width()});
+
+    // Provided a bias, add it to the result tensor across each output feature
+    if (B.has_value()) {
+        add_bias(result_ptr);
+    }
+
+    // Write over the content of the output with the result of the convolution
+    *Y = *result_ptr;
+}
+
+template <typename T>
+bool ConvNode<T>::areInputsFilled() const {
+    return X && X->get_size() > 0 &&
+           W && W->get_size() > 0 &&
+           (!B.has_value() || (B.value() && B.value()->get_size() > 0));
+}
+
+template <typename T>
+void ConvNode<T>::setInputs(const array_mml<GeneralDataTypes>& inputs) {
+    if (inputs.size() > 0) {
+        auto x_value = std::get<std::shared_ptr<AbstractTensor>>(inputs[0]);
+        *X = *x_value;
+    }
+
+    if (inputs.size() > 1) {
+        auto w_value = std::get<std::shared_ptr<AbstractTensor>>(inputs[1]);
+        *W = *w_value;
+    }
+
+    if (inputs.size() > 2 && B.has_value()) {
+        auto b_value = std::get<std::shared_ptr<AbstractTensor>>(inputs[2]);
+        *B.value() = *b_value;
+    }
+}
+
+template <typename T>
+bool ConvNode<T>::areOutputsFilled() const {
+    return Y && Y->get_size() > 0;
+}
+
+template <typename T>
+array_mml<GeneralDataTypes> ConvNode<T>::getOutputs() const {
+    return array_mml<GeneralDataTypes>{GeneralDataTypes(std::static_pointer_cast<AbstractTensor>(Y))};
+}
+
+template <typename T>
+void ConvNode<T>::flip_kernel() {
+    int height = get_kernel_height();
+    int width = get_kernel_width();
+
+    for (int f = 0; f < get_out_channels(); f++) {
+        for (int c = 0; c < get_in_channels(); c++) {
+            // Flip horizontally
+            for (int h = 0; h < height; h++) {
+                for (int w = 0; w < width / 2; w++) {
+                    auto tmp = (*W)[{f, c, h, w}];
+                    (*W)[{f, c, h, w}] = (*W)[{f, c, h, width - 1 - w}];
+                    (*W)[{f, c, h, width - 1 - w}] = tmp;
+                }
+            }
+
+            // Flip vertically
+            for (int w = 0; w < width; w++) {
+                for (int h = 0; h < height / 2; h++) {
+                    auto tmp = (*W)[{f, c, h, w}];
+                    (*W)[{f, c, h, w}] = (*W)[{f, c, height - h - 1, w}];
+                    (*W)[{f, c, height - 1 - h, w}] = tmp;
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void ConvNode<T>::im2col(shared_ptr<Tensor<T>> input, shared_ptr<Tensor<T>> output) {
+    // Iterate over each image in the batch
+    for (int n = 0; n < get_batch_size(); ++n) {
+        for (int h = 0; h < get_out_height(); ++h) {
+            for (int w = 0; w < get_out_width(); ++w) {
+                int col_index = h * get_out_width() + w;  // Column index in im2col matrix
+
+                for (int c = 0; c < get_in_channels(); ++c) {
+                    for (int kh = 0; kh < get_kernel_height(); ++kh) {
+                        for (int kw = 0; kw < get_kernel_width(); ++kw) {
+                            int input_h = h * get_stride_height() - get_padding_top() + kh;
+                            int input_w = w * get_stride_width() - get_padding_left() + kw;
+
+                            if (input_h < 0 || input_h >= get_in_height() + get_padding_bottom() ||
+                                input_w < 0 || input_w >= get_in_width() + get_padding_right()) {
+                                (*output)[col_index] = 0;  // Padding
+                            } else {
+                                int row_index = c * get_kernel_height() * get_kernel_width() + kh * get_kernel_width() + kw;
+
+                                int output_index = row_index * (get_out_height() * get_out_width()) + col_index;
+
+                                int input_index = n * (get_in_channels() * get_in_height() * get_in_width()) +
+                                                  c * (get_in_height() * get_in_width()) +
+                                                  input_h * get_in_width() + input_w;
+
+                                // Check if input index is valid
+                                if (input_index >= 0 && input_index < get_in_channels() * get_in_height() * get_in_width()) {
+                                    (*output)[output_index] = (*input)[input_index];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void ConvNode<T>::add_bias(shared_ptr<Tensor<T>> result_ptr) {
+    // We first have to retrieve the bias tensor inside the optional
+    auto& bias_tensor = *B;
+
+    for (int b = 0; b < get_batch_size(); b++) {
+        for (int i = 0; i < get_out_channels(); ++i) {
+            for (int h = 0; h < get_out_height(); ++h) {
+                for (int w = 0; w < get_out_width(); ++w) {
+                    int index = ((b * get_out_channels() + i) * get_out_height() + h) * get_out_width() + w;
+
+                    // Each value in bias vector is added to one entire out feature at a time
+                    (*result_ptr)[index] += (*bias_tensor)[i];
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void ConvNode<T>::validate_inputs() {
+    if (!areInputsFilled())
+        throw runtime_error("ConvNode inputs are not fully set.");
+
+    auto x_shape = X->get_shape();
+    if (x_shape.size() != 4)
+        throw runtime_error("Input tensor must have 4 dimensions: (Features x Channels x Height x Width)");
+
+    if (dilations.size() != 2) {
+        throw invalid_argument("Invalid dilations size. Expected a vector of size 2, but got: " +
+                               std::to_string(dilations.size()) + ".");
+    }
+
+    if (padding.size() != 4) {
+        throw invalid_argument("Invalid padding vector size. Expected a vector of size 4, but got: " +
+                               std::to_string(padding.size()) + ".");
+    }
+
+    if (kernel_shape.size() != 2) {
+        throw invalid_argument("Invalid kernel_shape vector size. Expected a vector of size 2, but got: " +
+                               std::to_string(kernel_shape.size()) + ".");
+    }
+
+    if (stride.size() != 2) {
+        throw invalid_argument("Invalid stride vector size. Expected a vector of size 2, but got: " +
+                               std::to_string(stride.size()) + ".");
+    }
+}
+
+template <typename T>
+int ConvNode<T>::get_batch_size() const { return batch_size; }
+
+template <typename T>
+int ConvNode<T>::get_in_channels() const { return in_channels; }
+
+template <typename T>
+int ConvNode<T>::get_in_height() const { return in_height; }
+
+template <typename T>
+int ConvNode<T>::get_in_width() const { return in_width; }
+
+template <typename T>
+int ConvNode<T>::get_kernel_height() const { return kernel_height; }
+
+template <typename T>
+int ConvNode<T>::get_kernel_width() const { return kernel_width; }
+
+template <typename T>
+int ConvNode<T>::get_out_channels() const { return out_channels; }
+
+template <typename T>
+int ConvNode<T>::get_stride_height() const { return stride[0]; }
+
+template <typename T>
+int ConvNode<T>::get_stride_width() const { return stride[1]; }
+
+template <typename T>
+int ConvNode<T>::get_padding_top() const { return padding[0]; }
+
+template <typename T>
+int ConvNode<T>::get_padding_bottom() const { return padding[1]; }
+
+template <typename T>
+int ConvNode<T>::get_padding_left() const { return padding[2]; }
+
+template <typename T>
+int ConvNode<T>::get_padding_right() const { return padding[3]; }
+
+template <typename T>
+int ConvNode<T>::get_out_height() {
+    return (get_in_height() + get_padding_top() + get_padding_bottom() - get_kernel_height()) / get_stride_height() + 1;
+}
+
+template <typename T>
+int ConvNode<T>::get_out_width() {
+    return (get_in_width() + get_padding_left() + get_padding_right() - get_kernel_width()) / get_stride_width() + 1;
+}

--- a/src/conv_node.tpp
+++ b/src/conv_node.tpp
@@ -135,10 +135,15 @@ void ConvNode<T>::im2col(shared_ptr<Tensor<T>> input, shared_ptr<Tensor<T>> outp
     // Iterate over each image in the batch
     for (int n = 0; n < get_batch_size(); ++n) {
         for (int h = 0; h < get_out_height(); ++h) {
-            for (int w = 0; w < get_out_width(); ++w) {
+            for (int w = 0; w < get_out_width(); ++w) {  // Traverse into each batch
+
                 int col_index = h * get_out_width() + w;  // Column index in im2col matrix
 
-                for (int c = 0; c < get_in_channels(); ++c) {
+                for (int c = 0; c < get_in_channels(); ++c) {  // If the input has multiple channels, iterate over each one
+
+                    // Here we loop over the kernel's height and width, simulating how the kernel moves across the input tensor.
+                    // For each position of the kernel, the corresponding input values are extracted and stored in the output tensor.
+                    // If the kernel extends beyond the boundaries of the input (due to padding or stride), zero padding is added instead of the input values.
                     for (int kh = 0; kh < get_kernel_height(); ++kh) {
                         for (int kw = 0; kw < get_kernel_width(); ++kw) {
                             int input_h = h * get_stride_height() - get_padding_top() + kh;

--- a/src/include/a_tensor.hpp
+++ b/src/include/a_tensor.hpp
@@ -2,6 +2,7 @@
 
 #include "array_mml.hpp"
 #include "globals.hpp"
+#include <string>
 
 #define ASSERT_ALLOWED_TYPE_T(T) static_assert(std::is_arithmetic_v<T>, "Tensor must have an arithmetic type.");
 

--- a/src/include/a_tensor.hpp
+++ b/src/include/a_tensor.hpp
@@ -2,7 +2,6 @@
 
 #include "array_mml.hpp"
 #include "globals.hpp"
-#include <string>
 
 #define ASSERT_ALLOWED_TYPE_T(T) static_assert(std::is_arithmetic_v<T>, "Tensor must have an arithmetic type.");
 

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -111,9 +111,28 @@ class ConvNode : public Node {
             im2col_output, im2col_output->get_shape()[1],
             0.0f,
             result_ptr, result_ptr->get_shape()[1]);
-
+            
         result_ptr->reshape({get_batch_size(), get_out_channels(), get_out_height(), get_out_width()});
-
+            
+        // The bias across each feature    
+        if (B.has_value()) {
+            
+            // We first have to retreive the bias tensor inside the optional
+            auto& bias_tensor = *B;
+        
+            for (int b = 0; b < get_batch_size(); b++) {
+                for (int i = 0; i < get_out_channels(); ++i) {
+                    for (int h = 0; h < get_out_height(); ++h) {
+                        for (int w = 0; w < get_out_width(); ++w) {
+                            int index = ((b * get_out_channels() + i) * get_out_height() + h) * get_out_width() + w;
+                            
+                            // Access the bias value for the current output channel (i)
+                            (*result_ptr)[index] += (*bias_tensor)[i];
+                        }
+                    }
+                }
+            }
+        }      
         *Y = *result_ptr;
     };
 

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "a_node.hpp"
+#include "globals.hpp"
+#include "mml_tensor.hpp"
+#include "mml_gemm.hpp"
+
+/**
+ * @class ConvNode
+ * @brief A class representing a Convolutional node in a computational graph.
+ *
+ * This class inherits from the Node class and represents a Conv node
+ * in a computational graph.
+ */
+template <typename T>
+class ConvNode : public Node {
+    static_assert(
+        std::is_same_v<T, double>   ||
+        std::is_same_v<T, float>  ||
+        std::is_same_v<T, uint>,
+        "GemmNode_T supports only double, float, int8");
+public:
+    using AbstractTensor = Tensor<T>;
+
+    /**
+     * @brief Constructor for ConvNode.
+     *
+     * @param X Shared pointer to the tensor X (data input).
+     * @param W Shared pointer to the tensor W (weights).
+     * @param B Optional shared pointer to the output tensor (bias).
+     * @param Y Shared pointer to the output tensor Y.
+     * @param dilations Dilation value along each spatial axis of the filter.
+     * @param padding The shape of the convolution kernel.
+     * @param kernel_shape The shape of the convolution kernel.
+     * @param stride Stride along each spatial axis.
+     * @param group number of groups input channels and out channels are divided into.
+     */
+    ConvNode(shared_ptr<AbstractTensor> X,
+             shared_ptr<AbstractTensor> W,
+             shared_ptr<AbstractTensor> Y,
+             vector<int> dilations,
+             vector<int> padding,
+             vector<int> kernel_shape,
+             vector<int> stride,
+             optional<shared_ptr<AbstractTensor>> B = std::nullopt,
+             int group = 1)
+      : X(X), W(W), B(B), Y(Y),
+        dilations(dilations), padding(padding), kernel_shape(kernel_shape), stride(stride) {}
+
+    /**
+     * @brief Perform the forward pass convolution computation.
+     *
+     * TODO.
+     */
+    void forward() override {
+        if (!areInputsFilled())
+            throw runtime_error("ConvNode inputs are not fully set.");
+
+        auto x_shape = X->get_shape();
+        if (x_shape.size() != 4)
+            throw runtime_error("Input tensor must have 4 dimensions: (Batches x Channels x Height x Width)");
+
+        Tensor<T> input_copy = X->copy();
+
+        //Tensor<T> im2col_matrix = tensor_mml<T>({output_width, output_height, in_channels * kernel_height * kernel_width});
+        return;
+    };
+
+    void im2col(Tensor<T> input, Tensor<T> output, vector<int> kernel_shape, vector<int> stride) {
+        return;
+    }
+    
+    /**
+     * @brief Check if the input(s) are filled.
+     * 
+     * @return True if the input(s) are filled, false otherwise.
+     */
+    bool areInputsFilled() const override {
+        return X && X->get_size() > 0 &&
+               W && W->get_size() > 0 &&
+               (!B.has_value() || (B.value() && B.value()->get_size() > 0));
+    }
+
+    /**
+     * @brief Set the input(s) for the node.
+     * 
+     * @param inputs The input data to be set, where A is inputs[0], B is inputs[1] and optionally C is inputs[2].
+     */
+    void setInputs(const array_mml<GeneralDataTypes>& inputs) override {
+        if (inputs.size() > 0) {
+            auto valueX = std::get<std::shared_ptr<AbstractTensor>>(inputs[0]);
+            *X = *valueX;
+        }
+            
+
+        if (inputs.size() > 1) {
+            auto valueW = std::get<std::shared_ptr<AbstractTensor>>(inputs[1]);
+            *W = *valueW;
+        }
+
+        if (inputs.size() > 2 && B.has_value()) {
+            auto valueB = std::get<std::shared_ptr<AbstractTensor>>(inputs[2]);
+            *B.value() = *valueB;
+        }
+    }
+
+    /**
+     * @brief Check if the output(s) are filled.
+     * 
+     * @return True if the output(s) are filled, false otherwise.
+     */
+    bool areOutputsFilled() const override {
+        return Y && Y->get_size() > 0;
+    }
+
+    /**
+     * @brief Get the output of the node.
+     * 
+     * @return The output data.
+     */
+    array_mml<GeneralDataTypes> getOutputs() const override {
+        return array_mml<GeneralDataTypes>{ GeneralDataTypes(std::static_pointer_cast<AbstractTensor>(Y)) };
+    }
+
+private:
+    // Inputs
+    shared_ptr<AbstractTensor> X; // Input data tensor A has size N x C x H x W.
+    shared_ptr<AbstractTensor> W; // The weight tensor used in the convolution.
+    optional<shared_ptr<AbstractTensor>> B; // Optional 1D bias tensor.
+
+    // Output
+    shared_ptr<AbstractTensor> Y; // Output tensor.
+
+    // Attributes
+    vector<int> dilations;
+    vector<int> padding;
+    vector<int> kernel_shape;
+    vector<int> stride;
+    int group;
+};

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -5,12 +5,18 @@
 #include "mml_gemm.hpp"
 #include "mml_tensor.hpp"
 
+
+// TODO Add bias functionality and testing
+// TODO Test that padding, stride and dilation work
+
 /**
  * @class ConvNode
  * @brief A class representing a Convolutional node in a computational graph.
  *
  * This class inherits from the Node class and represents a Conv node
  * in a computational graph.
+ * 
+ * @author Tim Carlsson (timca@chalmers.se)
  */
 template <typename T>
 class ConvNode : public Node {

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -5,7 +5,6 @@
 #include "mml_gemm.hpp"
 #include "mml_tensor.hpp"
 
-
 /**
  * @class ConvNode
  * @brief A class representing a Convolutional node in a computational graph.
@@ -18,9 +17,9 @@
 template <typename T>
 class ConvNode : public Node {
     static_assert(
-        std::is_same_v<T, double> || 
-        std::is_same_v<T, float>  || 
-        std::is_same_v<T, uint>,
+        std::is_same_v<T, double> ||
+            std::is_same_v<T, float> ||
+            std::is_same_v<T, uint>,
         "ConvNode_T only supports double, float, int");
 
    public:
@@ -51,27 +50,27 @@ class ConvNode : public Node {
 
     /**
      * @brief Performs the forward pass convolution operation.
-     * 
+     *
      * The method computes the forward convolution by performing the following steps:
-     * 
-     * 1. **Validate Inputs**: The method first checks that all the inputs are valid. This includes 
-     *    verifying the dimensions of the input tensor, kernel size, stride, padding, and other 
+     *
+     * 1. **Validate Inputs**: The method first checks that all the inputs are valid. This includes
+     *    verifying the dimensions of the input tensor, kernel size, stride, padding, and other
      *    convolution parameters to ensure compatibility.
-     * 
-     * 2. **Apply im2col Transformation**: The input tensor is transformed using the im2col operation. 
-     *    See explanation below. The transformed data is stored in a temporary tensor, ready 
+     *
+     * 2. **Apply im2col Transformation**: The input tensor is transformed using the im2col operation.
+     *    See explanation below. The transformed data is stored in a temporary tensor, ready
      *    for efficient matrix multiplication.
-     * 
-     * 3. **Perform GEMM (General Matrix Multiply)**: The core of the convolution operation is carried 
-     *    out using GEMM, which efficiently performs matrix multiplication. The im2col-transformed input 
-     *    tensor is multiplied with the kernel weights, which are reshaped appropriately. This operation 
-     *    produces the convolution results in the output tensor, which contains the feature maps after 
+     *
+     * 3. **Perform GEMM (General Matrix Multiply)**: The core of the convolution operation is carried
+     *    out using GEMM, which efficiently performs matrix multiplication. The im2col-transformed input
+     *    tensor is multiplied with the kernel weights, which are reshaped appropriately. This operation
+     *    produces the convolution results in the output tensor, which contains the feature maps after
      *    applying the kernel.
-     * 
+     *
      * 4. **Add Bias (Optional)**: If a bias term is specified, it is added to the output of the GEMM operation.
      *    This bias is applied across the feature maps and is typically used to adjust the activation of the convolutional layer.
-     * 
-     * 5. **Store Result in Output Tensor**: The final result of the convolution operation, after the 
+     *
+     * 5. **Store Result in Output Tensor**: The final result of the convolution operation, after the
      *    optional bias addition, is stored in the output tensor `Y`, which represents the convolved feature maps.
      */
     void forward() override;
@@ -108,7 +107,7 @@ class ConvNode : public Node {
     // Inputs
     /**
      * @brief Input data tensor containing the feature map(s) for the convolution.
-     * 
+     *
      * The input tensor typically has the shape [batch_size, in_channels, in_height, in_width].
      * This tensor represents the data that will be convolved with the kernel.
      */
@@ -116,32 +115,32 @@ class ConvNode : public Node {
 
     /**
      * @brief Weight tensor (kernel) used in the convolution.
-     * 
-     * The kernel tensor typically has the shape [out_channels, in_channels / group, kernel_height, kernel_width] 
+     *
+     * The kernel tensor typically has the shape [out_channels, in_channels / group, kernel_height, kernel_width]
      * for a grouped convolution. This tensor contains the filters that will be used to convolve the input tensor.
      */
     shared_ptr<AbstractTensor> W;
 
     /**
      * @brief Optional 1D bias tensor.
-     * 
-     * The bias tensor is added to the output feature map(s) after the convolution. 
+     *
+     * The bias tensor is added to the output feature map(s) after the convolution.
      * It is typically of shape [out_channels]. If not provided, no bias will be added.
      */
-    optional<shared_ptr<AbstractTensor>> B; 
+    optional<shared_ptr<AbstractTensor>> B;
 
     // Output
     /**
      * @brief Output tensor that holds the result of the convolution operation.
-     * 
-     * This tensor typically has the shape [batch_size, out_channels, out_height, out_width], 
+     *
+     * This tensor typically has the shape [batch_size, out_channels, out_height, out_width],
      * where the output feature map(s) will be stored after performing the convolution.
      */
     shared_ptr<AbstractTensor> Y;
 
     /**
      * @brief Dilation factors for each dimension of the kernel.
-     * 
+     *
      * Dilation controls the spacing between elements in the kernel. The default is typically [1, 1], meaning no dilation.
      * Dilation increases the receptive field of the kernel without increasing its size.
      */
@@ -149,88 +148,88 @@ class ConvNode : public Node {
 
     /**
      * @brief Padding to be applied to the input tensor before performing the convolution.
-     * 
-     * Padding for each spatial direction is represented as [top, bottom, left, right]. 
+     *
+     * Padding for each spatial direction is represented as [top, bottom, left, right].
      * Padding ensures that the convolution can be performed at the borders of the input tensor.
      */
     array_mml<int> padding;
 
     /**
      * @brief Shape of the kernel (filter).
-     * 
-     * The kernel shape typically has the format [kernel_height, kernel_width]. 
+     *
+     * The kernel shape typically has the format [kernel_height, kernel_width].
      * These dimensions determine the size of the region in the input tensor that will be convolved at each step.
      */
     array_mml<int> kernel_shape;
 
     /**
      * @brief Stride of the convolution operation.
-     * 
-     * Stride specifies the step size for moving the kernel across the input tensor. 
+     *
+     * Stride specifies the step size for moving the kernel across the input tensor.
      * It is typically represented as [vertical_stride, horizontal_stride].
      */
     array_mml<int> stride;
 
     /**
      * @brief Number of groups for grouped convolution.
-     * 
+     *
      * If set to 1, a standard convolution is performed. If greater than 1, the input channels are divided into groups,
      * and a grouped convolution is performed. Grouped convolutions can reduce computational complexity.
      */
     int group;
-    
+
     /**
      * @brief Height of the kernel (filter).
-     * 
+     *
      * Kernel height determines the vertical size of the region in the input tensor to be convolved.
      */
     int kernel_height;
 
     /**
      * @brief Width of the kernel (filter).
-     * 
+     *
      * Kernel width determines the horizontal size of the region in the input tensor to be convolved.
      */
     int kernel_width;
 
     /**
      * @brief Number of examples in the batch.
-     * 
+     *
      * The batch size represents how many input tensors will be processed at once.
      */
     int batch_size;
 
     /**
      * @brief Number of input channels.
-     * 
+     *
      * The input channels correspond to the depth of the input tensor, typically 3 for RGB images.
      */
     int in_channels;
 
     /**
      * @brief The height of the input tensor.
-     * 
+     *
      * This is the height of the input feature map(s).
      */
     int in_height;
 
     /**
      * @brief Width of the input tensor.
-     * 
+     *
      * This is the width of the input feature map(s).
      */
     int in_width;
 
     /**
      * @brief Number of output channels.
-     * 
+     *
      * The number of output channels corresponds to the number of filters used in the convolution.
      */
     int out_channels;
 
     /**
      * @brief Flips the content of each filter present in the weight kernel.
-     * 
+     *
      * This is done to perform the convolution correctly, otherwise the node would perform a cross-correlation computation
      */
     void flip_kernel();
@@ -238,21 +237,21 @@ class ConvNode : public Node {
     /**
      * @brief Performs the im2col transformation on the input tensor.
      *
-     * This method extracts patches from the input tensor and flattens them into columns, preparing 
-     * the data for efficient matrix multiplication in convolution operations. The im2col operation 
-     * unrolls local patches (based on kernel size, stride, and padding) into column vectors, making 
+     * This method extracts patches from the input tensor and flattens them into columns, preparing
+     * the data for efficient matrix multiplication in convolution operations. The im2col operation
+     * unrolls local patches (based on kernel size, stride, and padding) into column vectors, making
      * convolutions computationally more efficient.
      *
-     * @param input A shared pointer to the input tensor, typically of shape 
-     *              [batch_size, height, width, channels]. This is the data to be transformed into 
+     * @param input A shared pointer to the input tensor, typically of shape
+     *              [batch_size, height, width, channels]. This is the data to be transformed into
      *              columns by extracting patches for the convolution.
-     * 
-     * @param output A shared pointer to the output tensor, where the transformed data will be stored. 
-     *               It will have shape [batch_size, output_height * output_width, 
-     *               kernel_height * kernel_width * channels], representing the flattened patches 
+     *
+     * @param output A shared pointer to the output tensor, where the transformed data will be stored.
+     *               It will have shape [batch_size, output_height * output_width,
+     *               kernel_height * kernel_width * channels], representing the flattened patches
      *               ready for matrix multiplication.
-     * 
-     * @note The im2col operation prepares the input for matrix multiplication with kernel weights 
+     *
+     * @note The im2col operation prepares the input for matrix multiplication with kernel weights
      *       during convolution but does not compute the convolution itself.
      */
     void im2col(shared_ptr<Tensor<T>> input, shared_ptr<Tensor<T>> output);

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -86,8 +86,6 @@ public:
         array_mml<int> shapeW({get_out_channels(), flattened_size});
         auto flattened_weights = make_shared<Tensor_mml<T>>(shapeW);
 
-        auto W_tensor = dynamic_pointer_cast<Tensor_mml<T>>(W);
-
         // TODO Extract into private method
         // Write the values from the weight tensor (W) to the flattened tensor
         for (int oc = 0; oc < get_out_channels(); ++oc) {
@@ -96,7 +94,7 @@ public:
                     for (int kw = 0; kw < get_kernel_width(); ++kw) {
                         int flat_index = ic * get_kernel_height() * get_kernel_width() + kh * get_kernel_width() + kw;
                         (*flattened_weights)[oc * flattened_size + flat_index] =
-                            W_tensor->get_data()[oc * get_in_channels() * get_kernel_height() * get_kernel_width() + 
+                            (*W)[oc * get_in_channels() * get_kernel_height() * get_kernel_width() + 
                                         ic * get_kernel_height() * get_kernel_width() + 
                                         kh * get_kernel_width() + kw];
                     }

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -15,8 +15,8 @@
 template <typename T>
 class ConvNode : public Node {
     static_assert(
-        std::is_same_v<T, double>   ||
-        std::is_same_v<T, float>  ||
+        std::is_same_v<T, double> ||
+        std::is_same_v<T, float> ||
         std::is_same_v<T, uint>,
         "GemmNode_T supports only double, float, int8");
 public:
@@ -60,14 +60,86 @@ public:
         if (x_shape.size() != 4)
             throw runtime_error("Input tensor must have 4 dimensions: (Batches x Channels x Height x Width)");
 
-        Tensor<T> input_copy = X->copy();
+        // Create a copy of the input
+        auto input_copy = X->copy();
 
-        //Tensor<T> im2col_matrix = tensor_mml<T>({output_width, output_height, in_channels * kernel_height * kernel_width});
+        int batch_size = input_copy->get_shape()[0];
+        int in_channels = input_copy->get_shape()[1];
+        int in_height = input_copy->get_shape()[2];
+        int in_width = input_copy->get_shape()[3];
+
+        int kernel_height = W->get_shape()[0];
+        int kernel_width = W->get_shape()[1];
+        
+        int stride_h = stride[0]; // height stride
+        int stride_w = stride[1];
+        
+        int out_height = (in_height - kernel_height + 2 * padding[0]) / stride_h + 1;
+        int out_width = (in_width - kernel_width + 2 * padding[1]) / stride_w + 1;
+        
+        auto im2col_output = make_shared<Tensor_mml<T>>(std::initializer_list<int>{batch_size * out_height * out_width, in_channels * kernel_height * kernel_width});
+        
+        im2col(input_copy, im2col_output);
+        
         return;
     };
 
-    void im2col(Tensor<T> input, Tensor<T> output, vector<int> kernel_shape, vector<int> stride) {
-        return;
+    void im2col(shared_ptr<Tensor<T>> input, shared_ptr<Tensor<T>> output) {
+        // Get input and output dimensions
+        int batch_size = input->get_shape()[0];
+        int in_channels = input->get_shape()[1];
+        int in_height = input->get_shape()[2];
+        int in_width = input->get_shape()[3];
+
+        int kernel_height = W->get_shape()[0];
+        int kernel_width = W->get_shape()[1];
+
+        int stride_h = stride[0]; // height stride
+        int stride_w = stride[1]; // width stride
+
+        int padding_h = padding[0]; // padding on top and bottom
+        int padding_w = padding[1]; // padding on left and right
+
+        // Calculate the output height and width based on input size, kernel size, padding, and stride
+        int out_height = (in_height - kernel_height + 2 * padding_h) / stride_h + 1;
+        int out_width = (in_width - kernel_width + 2 * padding_w) / stride_w + 1;
+
+        // Iterate over each image in the batch
+        for (int n = 0; n < batch_size; ++n) {
+            for (int h = 0; h < out_height; ++h) {
+                for (int w = 0; w < out_width; ++w) {
+                    
+                    // Get the corresponding patch in the input tensor
+                    for (int c = 0; c < in_channels; ++c) {
+                        for (int kh = 0; kh < kernel_height; ++kh) {
+                            for (int kw = 0; kw < kernel_width; ++kw) {
+
+                                // Calculate the starting position of the patch in the input tensor
+                                int input_h = h * stride_h - padding_h + kh;
+                                int input_w = w * stride_w - padding_w + kw;
+
+                                // Check if within bounds
+                                if (input_h >= 0 && input_h < in_height && input_w >= 0 && input_w < in_width) {
+                                    // Place the value into the corresponding position in the output matrix
+                                    int output_index = (n * out_height * out_width + h * out_width + w) * (in_channels * kernel_height * kernel_width) +
+                                                    (c * kernel_height * kernel_width + kh * kernel_width + kw);
+                                    int input_index = n * (in_channels * in_height * in_width) + c * (in_height * in_width) + input_h * in_width + input_w;
+
+                                    (*output)[output_index] = (*input)[input_index];
+                                } else {
+                                    // If the patch goes out of bounds (due to padding), set it to 0
+                                    int output_index = (n * out_height * out_width + h * out_width + w) * (in_channels * kernel_height * kernel_width) +
+                                                    (c * kernel_height * kernel_width + kh * kernel_width + kw);
+                                    (*output)[output_index] = 0;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        std::cout << "im2col output shape: " << output->get_shape()[0] << " x " << output->get_shape()[1] << std::endl;
+        std::cout << std::endl;
     }
     
     /**

--- a/src/include/conv_node.hpp
+++ b/src/include/conv_node.hpp
@@ -39,10 +39,10 @@ public:
     ConvNode(shared_ptr<AbstractTensor> X,
              shared_ptr<AbstractTensor> W,
              shared_ptr<AbstractTensor> Y,
-             vector<int> dilations,
-             vector<int> padding,
-             vector<int> kernel_shape,
-             vector<int> stride,
+             array_mml<int> dilations,
+             array_mml<int> padding,
+             array_mml<int> kernel_shape,
+             array_mml<int> stride,
              optional<shared_ptr<AbstractTensor>> B = std::nullopt,
              int group = 1)
       : X(X), W(W), B(B), Y(Y),
@@ -235,10 +235,10 @@ private:
     shared_ptr<AbstractTensor> Y; // Output tensor.
 
     // Attributes
-    vector<int> dilations;
-    vector<int> padding;
-    vector<int> kernel_shape;
-    vector<int> stride;
+    array_mml<int> dilations;
+    array_mml<int> padding;
+    array_mml<int> kernel_shape;
+    array_mml<int> stride;
     int group;
 
     // Getters for input tensor dimensions

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -2,28 +2,24 @@
 
 #include <conv_node.hpp>
 
-
 TEST(ConvNodeTest, TestConstructor) {
     std::cout << "My test" << std::endl;
 
     array_mml<int> shapeX({1, 1, 3, 3});
-    array_mml<float> X_values({
-        1.0f, 2.0f, 3.0f,
-        4.0f, 5.0f, 6.0f,
-        7.0f, 8.0f, 9.0f});
+    array_mml<float> X_values({1.0f, 2.0f, 3.0f,
+                               4.0f, 5.0f, 6.0f,
+                               7.0f, 8.0f, 9.0f});
 
     array_mml<int> shapeW({1, 1, 2, 2});
-    array_mml<float> W_values({
-        1.0f, 0.0f, 
-        0.0, -1.0f});
+    array_mml<float> W_values({1.0f, 0.0f,
+                               0.0, -1.0f});
 
     shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
     shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
 
     array_mml<int> shapeY({1, 1, 2, 2});
-    array_mml<float> Y_values({
-        0.0f, 0.0f, 
-        0.0f, 0.0f});
+    array_mml<float> Y_values({0.0f, 0.0f,
+                               0.0f, 0.0f});
     auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
 
     array_mml<int> dilations = array_mml<int>({1, 1});
@@ -41,88 +37,17 @@ TEST(ConvNodeTest, TestConstructor) {
     ASSERT_EQ(Y->get_shape()[3], 2);  // Width
 }
 
-TEST(ConvNodeTest, TestImageToColumn) {
-
-    // Define the input tensor shape and values
-    array_mml<int> shapeX({1, 1, 3, 3});
-    array_mml<float> X_values({
-        1.0f, 2.0f, 3.0f,
-        4.0f, 5.0f, 6.0f,
-        7.0f, 8.0f, 9.0f
-    });
-
-    // Define the weight tensor shape and values (for testing im2col only, this might not be used)
-    array_mml<int> shapeW({1, 1, 2, 2});
-    array_mml<float> W_values({
-        1.0f, 0.0f, 
-        0.0f, -1.0f
-    });
-
-    // Create input and weight tensors
-    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
-    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
-
-    // Output tensor shape (after applying Conv)
-    array_mml<int> shapeY({1, 1, 2, 2});
-    array_mml<float> Y_values({
-        0.0f, 0.0f, 
-        0.0f, 0.0f
-    });
-    auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
-
-    // Setup other ConvNode parameters
-    array_mml<int> dilations = array_mml<int>({1, 1});
-    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
-    array_mml<int> kernel_shape = array_mml<int>({2, 2});
-    array_mml<int> stride = array_mml<int>({1, 1});
-
-    auto B = std::nullopt;
-
-    // Create ConvNode object
-    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 1);
-
-    int batch_size = X->get_shape()[0];    // 1
-    int in_channels = X->get_shape()[1];   // 1
-    int input_height = X->get_shape()[2];  // 3
-    int input_width = X->get_shape()[3];   // 3
-    int kernel_height = kernel_shape[0];   // 2 
-    int kernel_width = kernel_shape[1];    // 2
-    int padding_height = padding[0];       // 0
-    int padding_width = padding[1];        // 0
-    int stride_height = stride[0];         // 1
-    int stride_width = stride[1];          // 1
-
-    int output_height = ((input_height - kernel_height + 2 * padding_height) / stride_height) + 1;  // 2
-    int output_width = ((input_width - kernel_width + 2 * padding_width) / stride_width) + 1;      // 2
-
-    // Calculate the size of the im2col output
-    auto im2col_output = make_shared<Tensor_mml<float>>(std::initializer_list<int>{batch_size * output_height * output_width, in_channels * kernel_height * kernel_width});
-        
-    // Call im2col method (assuming you have it defined)
-    conv.im2col(X, im2col_output);
-
-    // Check the contents of im2col_output to ensure correctness
-    
-    EXPECT_EQ(im2col_output->get_shape()[0], 4);
-}
-
-
 TEST(ConvNodeTest, TestForward) {
-
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 1, 3, 3});
-    array_mml<float> X_values({
-        1.0f, 2.0f, 3.0f,
-        4.0f, 5.0f, 6.0f,
-        7.0f, 8.0f, 9.0f
-    });
+    array_mml<float> X_values({1.0f, 2.0f, 3.0f,
+                               4.0f, 5.0f, 6.0f,
+                               7.0f, 8.0f, 9.0f});
 
     // Define the weight tensor shape and values (for testing im2col only, this might not be used)
     array_mml<int> shapeW({1, 1, 2, 2});
-    array_mml<float> W_values({
-        1.0f, 1.0f, 
-        1.0f, 1.0f
-    });
+    array_mml<float> W_values({1.0f, 1.0f,
+                               1.0f, 1.0f});
 
     // Create input and weight tensors
     shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
@@ -130,11 +55,9 @@ TEST(ConvNodeTest, TestForward) {
 
     // Output tensor shape (after applying Conv)
     array_mml<int> shapeY({1, 1, 2, 2});
-    array_mml<float> Y_values({
-        0.0f, 0.0f, 
-        0.0f, 0.0f
-    });
-    
+    array_mml<float> Y_values({0.0f, 0.0f,
+                               0.0f, 0.0f});
+
     auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
 
     // Setup other ConvNode parameters
@@ -164,17 +87,40 @@ TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
     array_mml<int> shapeX({1, 1, 5, 5});
     array_mml<float> X_values({
         // Channel 1
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15,
-        16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
     });
 
     // Define the weight tensor (1 filter, 1 channels, 2x2 kernel)
     array_mml<int> shapeW({1, 1, 2, 2});
     array_mml<float> W_values({
-        1, 0, 0, -1,
+        1,
+        0,
+        0,
+        -1,
     });
 
     // Create input and weight tensors
@@ -184,7 +130,7 @@ TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
     // Define output tensor shape (1 batch, 8 output channels, 4x4 spatial size)
     array_mml<int> y_shape({1, 2, 3, 3});
 
-    auto Y = make_shared<Tensor_mml<float>>(y_shape);   
+    auto Y = make_shared<Tensor_mml<float>>(y_shape);
 
     // Define convolution parameters
     array_mml<int> dilations = array_mml<int>({1, 1});
@@ -192,7 +138,7 @@ TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
     array_mml<int> kernel_shape = array_mml<int>({2, 2});
     array_mml<int> stride = array_mml<int>({1, 1});
 
-    auto B = std::nullopt; // No bias
+    auto B = std::nullopt;  // No bias
 
     // Create ConvNode object
     ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 8);
@@ -203,7 +149,7 @@ TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
     EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 1, 4, 4}));
 
     // All values should be 6 as the distance from the first value in the kernel compared to the next is 6 for each stride
-    // This additionally checks that the kernel was flipped correctly as the expected value otherwise would be -6 
+    // This additionally checks that the kernel was flipped correctly as the expected value otherwise would be -6
     for (int i = 0; i < Y->get_size(); i++) {
         EXPECT_NEAR(Y->get_data()[i], 6.0f, 1e-5);
     }
@@ -214,41 +160,99 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
     array_mml<int> shapeX({1, 3, 5, 5});
     array_mml<float> X_values({
         // Channel 1
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15,
-        16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
-        
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+
         // Channel 2
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15,
-        16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
-        
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+
         // Channel 3
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15,
-        16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
     });
 
     // Define the weight tensor (8 filters, each with 3 channels, 2x2 kernel)
     // The above dimensions mean that the convolution will extract 8 total features
     array_mml<int> shapeW({8, 3, 2, 2});
-    array_mml<float> W_values({
-        // 8 filters, each with 3 input channels
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1,  // These are the filters
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1,  
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
-        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1 
-    });
+    array_mml<float> W_values({                                        // 8 filters, each with 3 input channels
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,  // These are the filters
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1,
+                               1, 0, 0, -1, 1, 0, 0, -1, 1, 0, 0, -1});
 
     // Create input and weight tensors
     shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
@@ -257,7 +261,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
     // Set the size wrong intentionally to check that it gets reshapen correctly within forward()
     array_mml<int> y_shape({1, 2, 3, 3});
 
-    auto Y = make_shared<Tensor_mml<float>>(y_shape);   
+    auto Y = make_shared<Tensor_mml<float>>(y_shape);
 
     // Define convolution parameters
     array_mml<int> dilations = array_mml<int>({1, 1});
@@ -265,7 +269,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
     array_mml<int> kernel_shape = array_mml<int>({2, 2});
     array_mml<int> stride = array_mml<int>({1, 1});
 
-    auto B = std::nullopt; // No bias
+    auto B = std::nullopt;  // No bias
 
     // Create ConvNode object
     ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 8);
@@ -278,52 +282,47 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
     // This time as we have 3 in_channels
     // The value after applying the filter should be 6 + 6 + 6 = 18
     for (int i = 0; i < Y->get_size(); i++) {
-        EXPECT_NEAR(Y->get_data()[i], 18.0f, 1e-5); 
+        EXPECT_NEAR(Y->get_data()[i], 18.0f, 1e-5);
     }
 }
-
 
 TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
     // The purpose of this test is to check if our implementation is the same as using scipy convolve2d implementation
 
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 3, 5, 5});
-    array_mml<float> X_values({
-        // Channel 1
-        1, 2, 3, 4, 5,
-        6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15,
-        16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
-        
-        // Channel 2
-        1, 1, 1, 1, 1,
-        2, 2, 2, 2, 2,
-        3, 3, 3, 3, 3,
-        4, 4, 4, 4, 4,
-        5, 5, 5, 5, 5,
-        
-        // Channel 3
-        0, 1, 0, 1, 0,
-        1, 0, 1, 0, 1,
-        0, 1, 0, 1, 0,
-        1, 0, 1, 0, 1,
-        0, 1, 0, 1, 0
-    });
+    array_mml<float> X_values({// Channel 1
+                               1, 2, 3, 4, 5,
+                               6, 7, 8, 9, 10,
+                               11, 12, 13, 14, 15,
+                               16, 17, 18, 19, 20,
+                               21, 22, 23, 24, 25,
+
+                               // Channel 2
+                               1, 1, 1, 1, 1,
+                               2, 2, 2, 2, 2,
+                               3, 3, 3, 3, 3,
+                               4, 4, 4, 4, 4,
+                               5, 5, 5, 5, 5,
+
+                               // Channel 3
+                               0, 1, 0, 1, 0,
+                               1, 0, 1, 0, 1,
+                               0, 1, 0, 1, 0,
+                               1, 0, 1, 0, 1,
+                               0, 1, 0, 1, 0});
 
     // Define the weight tensor (8 filters, each with 3 channels, 2x2 kernel)
     array_mml<int> shapeW({8, 3, 2, 2});
-    array_mml<float> W_values({
-        // 8 filters, each with 3 input channels
-        1, 0, 0, -1,   0, 1, -1, 0,   1, -1, 0, 1,  // Filter 1
-        -1, 1, 1, 0,   0, -1, 1, 1,   1, 0, -1, -1, // Filter 2
-        1, 1, 0, -1,   1, 0, -1, -1,  -1, 1, 1, 0,  // Filter 3
-        0, -1, 1, 1,   -1, -1, 1, 0,   1, 0, -1, 1, // Filter 4
-        1, 0, -1, 1,   1, -1, -1, 0,   -1, 1, 1, 0, // Filter 5
-        -1, 1, 0, -1,   0, 1, 1, -1,   1, -1, 0, 1, // Filter 6
-        1, -1, 1, 0,   0, 1, -1, 1,   -1, 1, 0, -1, // Filter 7
-        0, 1, -1, 1,   -1, 1, 0, -1,   1, 0, 1, -1  // Filter 8
-    });
+    array_mml<float> W_values({// 8 filters, each with 3 input channels
+                               1, 0, 0, -1, 0, 1, -1, 0, 1, -1, 0, 1,
+                               -1, 1, 1, 0, 0, -1, 1, 1, 1, 0, -1, -1,
+                               1, 1, 0, -1, 1, 0, -1, -1, -1, 1, 1, 0,
+                               0, -1, 1, 1, -1, -1, 1, 0, 1, 0, -1, 1,
+                               1, 0, -1, 1, 1, -1, -1, 0, -1, 1, 1, 0,
+                               -1, 1, 0, -1, 0, 1, 1, -1, 1, -1, 0, 1,
+                               1, -1, 1, 0, 0, 1, -1, 1, -1, 1, 0, -1,
+                               0, 1, -1, 1, -1, 1, 0, -1, 1, 0, 1, -1});
 
     // Create input and weight tensors
     shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
@@ -332,7 +331,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
     // Define output tensor shape (1 batch, 8 output channels, 4x4 spatial size)
     array_mml<int> y_shape({1, 8, 4, 4});
 
-    auto Y = make_shared<Tensor_mml<float>>(y_shape);   
+    auto Y = make_shared<Tensor_mml<float>>(y_shape);
 
     // Define convolution parameters
     array_mml<int> dilations = array_mml<int>({1, 1});
@@ -340,7 +339,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
     array_mml<int> kernel_shape = array_mml<int>({2, 2});
     array_mml<int> stride = array_mml<int>({1, 1});
 
-    auto B = std::nullopt; // No bias
+    auto B = std::nullopt;  // No bias
 
     // Create ConvNode object
     ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 8);
@@ -352,53 +351,47 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
 
     // Expected values (8 extracted feature maps each 4x4)
     // These were calculated using SciPy convolve2d function with the same parameters as above
-    vector<float> expected_values({
-        6.0, 9.0, 6.0, 9.0,
-        9.0, 6.0, 9.0, 6.0,
-        6.0, 9.0, 6.0, 9.0,
-        9.0, 6.0, 9.0, 6.0,
+    vector<float> expected_values({6.0, 9.0, 6.0, 9.0,
+                                   9.0, 6.0, 9.0, 6.0,
+                                   6.0, 9.0, 6.0, 9.0,
+                                   9.0, 6.0, 9.0, 6.0,
 
-        0.0, 2.0, 2.0, 4.0,
-        7.0, 7.0, 9.0, 9.0,
-        12.0, 14.0, 14.0, 16.0,
-        19.0, 19.0, 21.0, 21.0,
+                                   0.0, 2.0, 2.0, 4.0,
+                                   7.0, 7.0, 9.0, 9.0,
+                                   12.0, 14.0, 14.0, 16.0,
+                                   19.0, 19.0, 21.0, 21.0,
 
-        14.0, 12.0, 16.0, 14.0,
-        15.0, 19.0, 17.0, 21.0,
-        22.0, 20.0, 24.0, 22.0,
-        23.0, 27.0, 25.0, 29.0,
+                                   14.0, 12.0, 16.0, 14.0,
+                                   15.0, 19.0, 17.0, 21.0,
+                                   22.0, 20.0, 24.0, 22.0,
+                                   23.0, 27.0, 25.0, 29.0,
 
-        -7.0, -3.0, -5.0, -1.0,
-        0.0, -2.0, 2.0, 0.0,
-        1.0, 5.0, 3.0, 7.0,
-        8.0, 6.0, 10.0, 8.0,
+                                   -7.0, -3.0, -5.0, -1.0,
+                                   0.0, -2.0, 2.0, 0.0,
+                                   1.0, 5.0, 3.0, 7.0,
+                                   8.0, 6.0, 10.0, 8.0,
 
-        7.0, 5.0, 9.0, 7.0,
-        8.0, 12.0, 10.0, 14.0,
-        15.0, 13.0, 17.0, 15.0,
-        16.0, 20.0, 18.0, 22.0,
+                                   7.0, 5.0, 9.0, 7.0,
+                                   8.0, 12.0, 10.0, 14.0,
+                                   15.0, 13.0, 17.0, 15.0,
+                                   16.0, 20.0, 18.0, 22.0,
 
-        -1.0, 1.0, -3.0, -1.0,
-        -2.0, -6.0, -4.0, -8.0,
-        -9.0, -7.0, -11.0, -9.0,
-        -10.0, -14.0, -12.0, -16.0,
+                                   -1.0, 1.0, -3.0, -1.0,
+                                   -2.0, -6.0, -4.0, -8.0,
+                                   -9.0, -7.0, -11.0, -9.0,
+                                   -10.0, -14.0, -12.0, -16.0,
 
-        6.0, 4.0, 8.0, 6.0,
-        9.0, 13.0, 11.0, 15.0,
-        18.0, 16.0, 20.0, 18.0,
-        21.0, 25.0, 23.0, 27.0,
+                                   6.0, 4.0, 8.0, 6.0,
+                                   9.0, 13.0, 11.0, 15.0,
+                                   18.0, 16.0, 20.0, 18.0,
+                                   21.0, 25.0, 23.0, 27.0,
 
-        5.0, 5.0, 7.0, 7.0,
-        8.0, 10.0, 10.0, 12.0,
-        13.0, 13.0, 15.0, 15.0,
-        16.0, 18.0, 18.0, 20.0
-    });
+                                   5.0, 5.0, 7.0, 7.0,
+                                   8.0, 10.0, 10.0, 12.0,
+                                   13.0, 13.0, 15.0, 15.0,
+                                   16.0, 18.0, 18.0, 20.0});
 
-    // Check expected values (since exact values depend on conv implementation, verifying non-zero output)
     for (int i = 0; i < Y->get_size(); i++) {
-        EXPECT_NEAR(Y->get_data()[i], expected_values.at(i), 1e-5); // Values should not be zero if computed correctly
+        EXPECT_NEAR(Y->get_data()[i], expected_values.at(i), 1e-5);
     }
 }
-
-
-

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -120,8 +120,8 @@ TEST(ConvNodeTest, TestForward) {
     // Define the weight tensor shape and values (for testing im2col only, this might not be used)
     array_mml<int> shapeW({1, 1, 2, 2});
     array_mml<float> W_values({
-        1.0f, 0.0f, 
-        0.0f, -1.0f
+        1.0f, 1.0f, 
+        1.0f, 1.0f
     });
 
     // Create input and weight tensors
@@ -152,13 +152,140 @@ TEST(ConvNodeTest, TestForward) {
 
     // The output is reshaped during the call to forward so we want to make sure that the size is correct
     EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 1, 2, 2}));
-    for (int i = 0; i<Y->get_size(); i++) {
-        EXPECT_FLOAT_EQ(Y->get_data()[i], -4); // All values in the result should be -4
+
+    EXPECT_FLOAT_EQ(Y->get_data()[0], 12);
+    EXPECT_FLOAT_EQ(Y->get_data()[1], 16);
+    EXPECT_FLOAT_EQ(Y->get_data()[2], 24);
+    EXPECT_FLOAT_EQ(Y->get_data()[3], 28);
+}
+
+TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
+    // The purpose of this test is to check that the convolution node is able to handle multiple input and output channels
+    array_mml<int> shapeX({1, 1, 5, 5});
+    array_mml<float> X_values({
+        // Channel 1
+        1, 2, 3, 4, 5,
+        6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25,
+    });
+
+    // Define the weight tensor (1 filter, 1 channels, 2x2 kernel)
+    array_mml<int> shapeW({1, 1, 2, 2});
+    array_mml<float> W_values({
+        1, 0, 0, -1,
+    });
+
+    // Create input and weight tensors
+    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
+    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
+
+    // Define output tensor shape (1 batch, 8 output channels, 4x4 spatial size)
+    array_mml<int> y_shape({1, 2, 3, 3});
+
+    auto Y = make_shared<Tensor_mml<float>>(y_shape);   
+
+    // Define convolution parameters
+    array_mml<int> dilations = array_mml<int>({1, 1});
+    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
+    array_mml<int> kernel_shape = array_mml<int>({2, 2});
+    array_mml<int> stride = array_mml<int>({1, 1});
+
+    auto B = std::nullopt; // No bias
+
+    // Create ConvNode object
+    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 8);
+
+    conv.forward();
+
+    // Should extract 16 patches from the feature in a 4x4 matrix
+    EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 1, 4, 4}));
+
+    // All values should be 6 as the distance from the first value in the kernel compared to the next is 6 for each stride
+    // This additionally checks that the kernel was flipped correctly as the expected value otherwise would be -6 
+    for (int i = 0; i < Y->get_size(); i++) {
+        EXPECT_NEAR(Y->get_data()[i], 6.0f, 1e-5);
     }
-    //EXPECT_EQ(1, 2);
 }
 
 TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
+    // The purpose of this test is to check that the convolution node is able to handle multiple input and output channels
+    array_mml<int> shapeX({1, 3, 5, 5});
+    array_mml<float> X_values({
+        // Channel 1
+        1, 2, 3, 4, 5,
+        6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25,
+        
+        // Channel 2
+        1, 2, 3, 4, 5,
+        6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25,
+        
+        // Channel 3
+        1, 2, 3, 4, 5,
+        6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25,
+    });
+
+    // Define the weight tensor (8 filters, each with 3 channels, 2x2 kernel)
+    // The above dimensions mean that the convolution will extract 8 total features
+    array_mml<int> shapeW({8, 3, 2, 2});
+    array_mml<float> W_values({
+        // 8 filters, each with 3 input channels
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1,  // These are the filters
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1,  
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1, 
+        1, 0, 0, -1,   1, 0, 0, -1,   1, 0, 0, -1 
+    });
+
+    // Create input and weight tensors
+    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
+    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
+
+    // Set the size wrong intentionally to check that it gets reshapen correctly within forward()
+    array_mml<int> y_shape({1, 2, 3, 3});
+
+    auto Y = make_shared<Tensor_mml<float>>(y_shape);   
+
+    // Define convolution parameters
+    array_mml<int> dilations = array_mml<int>({1, 1});
+    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
+    array_mml<int> kernel_shape = array_mml<int>({2, 2});
+    array_mml<int> stride = array_mml<int>({1, 1});
+
+    auto B = std::nullopt; // No bias
+
+    // Create ConvNode object
+    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 8);
+
+    conv.forward();
+
+    // Check output shape
+    EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 8, 4, 4}));
+
+    // This time as we have 3 in_channels
+    // The value after applying the filter should be 6 + 6 + 6 = 18
+    for (int i = 0; i < Y->get_size(); i++) {
+        EXPECT_NEAR(Y->get_data()[i], 18.0f, 1e-5); 
+    }
+}
+
+
+TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
+    // The purpose of this test is to check if our implementation is the same as using scipy convolve2d implementation
+
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 3, 5, 5});
     array_mml<float> X_values({
@@ -228,4 +355,6 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
         EXPECT_NEAR(Y->get_data()[i], 0.0f, 1e-5); // Values should not be zero if computed correctly
     }
 }
+
+
 

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include <conv_node.hpp>
+
+
+TEST(ConvNodeTest, basics) {
+
+    Tensor_mml<float> input({1, 1, 3, 3}, {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+    
+}

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -2,7 +2,7 @@
 
 #include <conv_node.hpp>
 
-TEST(ConvNodeTest, TestConstructor) {
+TEST(conv_node_test, test_constructor) {
     std::cout << "My test" << std::endl;
 
     array_mml<int> shapeX({1, 1, 3, 3});
@@ -37,7 +37,7 @@ TEST(ConvNodeTest, TestConstructor) {
     ASSERT_EQ(Y->get_shape()[3], 2);  // Width
 }
 
-TEST(ConvNodeTest, TestForward) {
+TEST(conv_node_test, test_forward_simple) {
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 1, 3, 3});
     array_mml<float> X_values({1.0f, 2.0f, 3.0f,
@@ -82,7 +82,7 @@ TEST(ConvNodeTest, TestForward) {
     EXPECT_FLOAT_EQ(Y->get_data()[3], 28);
 }
 
-TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
+TEST(conv_node_test, test_forward_5x5input_2x2filter) {
     // The purpose of this test is to check that the convolution node is able to handle multiple input and output channels
     array_mml<int> shapeX({1, 1, 5, 5});
     array_mml<float> X_values({
@@ -155,7 +155,7 @@ TEST(ConvNodeTest, TestForward_5x5Input_2x2Filter) {
     }
 }
 
-TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
+TEST(conv_node_test, test_forward_three_in_channels_eight_out_channels) {
     // The purpose of this test is to check that the convolution node is able to handle multiple input and output channels
     array_mml<int> shapeX({1, 3, 5, 5});
     array_mml<float> X_values({
@@ -286,7 +286,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels) {
     }
 }
 
-TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
+TEST(conv_node_test, test_forward_3_in_channels_8_out_channels_scipy_comparison) {
     // The purpose of this test is to check if our implementation is the same as using scipy convolve2d implementation
 
     // Define the input tensor shape and values
@@ -396,7 +396,7 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
     }
 }
 
-TEST(ConvNodeTest, TestBiasAdd) {
+TEST(conv_node_test, test_bias_add) {
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 1, 3, 3});
     array_mml<float> X_values({1.0f, 2.0f, 3.0f,
@@ -444,7 +444,7 @@ TEST(ConvNodeTest, TestBiasAdd) {
     EXPECT_FLOAT_EQ(Y->get_data()[3], 38);
 }
 
-TEST(ConvNodeTest, TestBias_MultipleOutChannels) {
+TEST(conv_node_test, test_bias_multiple_out_channels) {
     // The purpose of this test is to check that the convolution node is able to handle multiple input and output channels
     array_mml<int> shapeX({1, 3, 5, 5});
     array_mml<float> X_values({
@@ -588,7 +588,7 @@ TEST(ConvNodeTest, TestBias_MultipleOutChannels) {
     }
 }
 
-TEST(ConvNodeTest, TestPadding) {
+TEST(conv_node_test, TestPadding) {
     // Define the input tensor shape and values
     array_mml<int> shapeX({1, 1, 3, 3});
     array_mml<float> X_values({1.0f, 2.0f, 3.0f,

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -150,7 +150,10 @@ TEST(ConvNodeTest, TestForward) {
 
     conv.forward();
 
-    // Check the contents of im2col_output to ensure correctness
-    
-    EXPECT_EQ(1, 2);
+    // The output is reshaped during the call to forward so we want to make sure that the size is correct
+    EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 1, 2, 2}));
+    for (int i = 0; i<Y->get_size(); i++) {
+        EXPECT_FLOAT_EQ(Y->get_data()[i], -4); // All values in the result should be -4
+    }
+    //EXPECT_EQ(1, 2);
 }

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -26,10 +26,10 @@ TEST(ConvNodeTest, TestConstructor) {
         0.0f, 0.0f});
     auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
 
-    std::vector<int> dilations = {1, 1};
-    std::vector<int> padding = {0, 0, 0, 0};
-    std::vector<int> kernel_shape = {2, 2};
-    std::vector<int> stride = {1, 1};
+    array_mml<int> dilations = array_mml<int>({1, 1});
+    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
+    array_mml<int> kernel_shape = array_mml<int>({2, 2});
+    array_mml<int> stride = array_mml<int>({1, 1});
 
     auto B = std::nullopt;
 
@@ -71,10 +71,10 @@ TEST(ConvNodeTest, TestImageToColumn) {
     auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
 
     // Setup other ConvNode parameters
-    std::vector<int> dilations = {1, 1};
-    std::vector<int> padding = {0, 0, 0, 0};
-    std::vector<int> kernel_shape = {2, 2};
-    std::vector<int> stride = {1, 1};
+    array_mml<int> dilations = array_mml<int>({1, 1});
+    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
+    array_mml<int> kernel_shape = array_mml<int>({2, 2});
+    array_mml<int> stride = array_mml<int>({1, 1});
 
     auto B = std::nullopt;
 
@@ -138,10 +138,10 @@ TEST(ConvNodeTest, TestForward) {
     auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
 
     // Setup other ConvNode parameters
-    std::vector<int> dilations = {1, 1};
-    std::vector<int> padding = {0, 0, 0, 0};
-    std::vector<int> kernel_shape = {2, 2};
-    std::vector<int> stride = {1, 1};
+    array_mml<int> dilations = array_mml<int>({1, 1});
+    array_mml<int> padding = array_mml<int>({0, 0, 0, 0});
+    array_mml<int> kernel_shape = array_mml<int>({2, 2});
+    array_mml<int> stride = array_mml<int>({1, 1});
 
     auto B = std::nullopt;
 

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -102,5 +102,55 @@ TEST(ConvNodeTest, TestImageToColumn) {
     conv.im2col(X, im2col_output);
 
     // Check the contents of im2col_output to ensure correctness
-    std::cout << "Halooooooooooooooooooooo" << std::endl;
+    
+    EXPECT_EQ(im2col_output->get_shape()[0], 4);
+}
+
+
+TEST(ConvNodeTest, TestForward) {
+
+    // Define the input tensor shape and values
+    array_mml<int> shapeX({1, 1, 3, 3});
+    array_mml<float> X_values({
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f,
+        7.0f, 8.0f, 9.0f
+    });
+
+    // Define the weight tensor shape and values (for testing im2col only, this might not be used)
+    array_mml<int> shapeW({1, 1, 2, 2});
+    array_mml<float> W_values({
+        1.0f, 0.0f, 
+        0.0f, -1.0f
+    });
+
+    // Create input and weight tensors
+    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
+    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
+
+    // Output tensor shape (after applying Conv)
+    array_mml<int> shapeY({1, 1, 2, 2});
+    array_mml<float> Y_values({
+        0.0f, 0.0f, 
+        0.0f, 0.0f
+    });
+    
+    auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
+
+    // Setup other ConvNode parameters
+    std::vector<int> dilations = {1, 1};
+    std::vector<int> padding = {0, 0, 0, 0};
+    std::vector<int> kernel_shape = {2, 2};
+    std::vector<int> stride = {1, 1};
+
+    auto B = std::nullopt;
+
+    // Create ConvNode object
+    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 1);
+
+    conv.forward();
+
+    // Check the contents of im2col_output to ensure correctness
+    
+    EXPECT_EQ(1, 2);
 }

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -350,9 +350,53 @@ TEST(ConvNodeTest, TestForward_3InChannels_8OutChannels_SciPyComparison) {
     // Check output shape
     EXPECT_EQ(Y->get_shape(), array_mml<int>({1, 8, 4, 4}));
 
+    // Expected values (8 extracted feature maps each 4x4)
+    // These were calculated using SciPy convolve2d function with the same parameters as above
+    vector<float> expected_values({
+        6.0, 9.0, 6.0, 9.0,
+        9.0, 6.0, 9.0, 6.0,
+        6.0, 9.0, 6.0, 9.0,
+        9.0, 6.0, 9.0, 6.0,
+
+        0.0, 2.0, 2.0, 4.0,
+        7.0, 7.0, 9.0, 9.0,
+        12.0, 14.0, 14.0, 16.0,
+        19.0, 19.0, 21.0, 21.0,
+
+        14.0, 12.0, 16.0, 14.0,
+        15.0, 19.0, 17.0, 21.0,
+        22.0, 20.0, 24.0, 22.0,
+        23.0, 27.0, 25.0, 29.0,
+
+        -7.0, -3.0, -5.0, -1.0,
+        0.0, -2.0, 2.0, 0.0,
+        1.0, 5.0, 3.0, 7.0,
+        8.0, 6.0, 10.0, 8.0,
+
+        7.0, 5.0, 9.0, 7.0,
+        8.0, 12.0, 10.0, 14.0,
+        15.0, 13.0, 17.0, 15.0,
+        16.0, 20.0, 18.0, 22.0,
+
+        -1.0, 1.0, -3.0, -1.0,
+        -2.0, -6.0, -4.0, -8.0,
+        -9.0, -7.0, -11.0, -9.0,
+        -10.0, -14.0, -12.0, -16.0,
+
+        6.0, 4.0, 8.0, 6.0,
+        9.0, 13.0, 11.0, 15.0,
+        18.0, 16.0, 20.0, 18.0,
+        21.0, 25.0, 23.0, 27.0,
+
+        5.0, 5.0, 7.0, 7.0,
+        8.0, 10.0, 10.0, 12.0,
+        13.0, 13.0, 15.0, 15.0,
+        16.0, 18.0, 18.0, 20.0
+    });
+
     // Check expected values (since exact values depend on conv implementation, verifying non-zero output)
     for (int i = 0; i < Y->get_size(); i++) {
-        EXPECT_NEAR(Y->get_data()[i], 0.0f, 1e-5); // Values should not be zero if computed correctly
+        EXPECT_NEAR(Y->get_data()[i], expected_values.at(i), 1e-5); // Values should not be zero if computed correctly
     }
 }
 

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -3,8 +3,104 @@
 #include <conv_node.hpp>
 
 
-TEST(ConvNodeTest, basics) {
+TEST(ConvNodeTest, TestConstructor) {
+    std::cout << "My test" << std::endl;
 
-    Tensor_mml<float> input({1, 1, 3, 3}, {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
-    
+    array_mml<int> shapeX({1, 1, 3, 3});
+    array_mml<float> X_values({
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f,
+        7.0f, 8.0f, 9.0f});
+
+    array_mml<int> shapeW({1, 1, 2, 2});
+    array_mml<float> W_values({
+        1.0f, 0.0f, 
+        0.0, -1.0f});
+
+    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
+    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
+
+    array_mml<int> shapeY({1, 1, 2, 2});
+    array_mml<float> Y_values({
+        0.0f, 0.0f, 
+        0.0f, 0.0f});
+    auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
+
+    std::vector<int> dilations = {1, 1};
+    std::vector<int> padding = {0, 0, 0, 0};
+    std::vector<int> kernel_shape = {2, 2};
+    std::vector<int> stride = {1, 1};
+
+    auto B = std::nullopt;
+
+    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 1);
+
+    ASSERT_EQ(Y->get_shape()[0], 1);  // Batch size
+    ASSERT_EQ(Y->get_shape()[1], 1);  // Channels
+    ASSERT_EQ(Y->get_shape()[2], 2);  // Height
+    ASSERT_EQ(Y->get_shape()[3], 2);  // Width
+}
+
+TEST(ConvNodeTest, TestImageToColumn) {
+
+    // Define the input tensor shape and values
+    array_mml<int> shapeX({1, 1, 3, 3});
+    array_mml<float> X_values({
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f,
+        7.0f, 8.0f, 9.0f
+    });
+
+    // Define the weight tensor shape and values (for testing im2col only, this might not be used)
+    array_mml<int> shapeW({1, 1, 2, 2});
+    array_mml<float> W_values({
+        1.0f, 0.0f, 
+        0.0f, -1.0f
+    });
+
+    // Create input and weight tensors
+    shared_ptr<Tensor_mml<float>> X = make_shared<Tensor_mml<float>>(shapeX, X_values);
+    shared_ptr<Tensor_mml<float>> W = make_shared<Tensor_mml<float>>(shapeW, W_values);
+
+    // Output tensor shape (after applying Conv)
+    array_mml<int> shapeY({1, 1, 2, 2});
+    array_mml<float> Y_values({
+        0.0f, 0.0f, 
+        0.0f, 0.0f
+    });
+    auto Y = make_shared<Tensor_mml<float>>(shapeY, Y_values);
+
+    // Setup other ConvNode parameters
+    std::vector<int> dilations = {1, 1};
+    std::vector<int> padding = {0, 0, 0, 0};
+    std::vector<int> kernel_shape = {2, 2};
+    std::vector<int> stride = {1, 1};
+
+    auto B = std::nullopt;
+
+    // Create ConvNode object
+    ConvNode<float> conv(X, W, Y, dilations, padding, kernel_shape, stride, B, 1);
+
+    int batch_size = X->get_shape()[0];    // 1
+    int in_channels = X->get_shape()[1];   // 1
+    int input_height = X->get_shape()[2];  // 3
+    int input_width = X->get_shape()[3];   // 3
+    int kernel_height = kernel_shape[0];   // 2 
+    int kernel_width = kernel_shape[1];    // 2
+    int padding_height = padding[0];       // 0
+    int padding_width = padding[1];        // 0
+    int stride_height = stride[0];         // 1
+    int stride_width = stride[1];          // 1
+
+    int output_height = ((input_height - kernel_height + 2 * padding_height) / stride_height) + 1;  // 2
+    int output_width = ((input_width - kernel_width + 2 * padding_width) / stride_width) + 1;      // 2
+
+    // Calculate the size of the im2col output
+    auto im2col_output = make_shared<Tensor_mml<float>>(std::initializer_list<int>{batch_size * output_height * output_width, in_channels * kernel_height * kernel_width});
+        
+    // Call im2col method (assuming you have it defined)
+    conv.im2col(X, im2col_output);
+
+    // Check the contents of im2col_output to ensure correctness
+    std::cout << "Halooooooooooooooooooooo" << std::endl;
 }


### PR DESCRIPTION
### Description
Implemented the Conv node as specified in the onnx documentation, handling the convolution operation for multi-channel inputs and multiple filters. This implementation supports various configurations such as different padding, stride, and kernel sizes, 

The dilation and group parameters are not used in either AlexNet and LeNet so i chose to put those on hold for now, to focus on other features of the framework instead.

### Issue
Closes #41 

### Testing
Implemented tests to verify the correctness of the Conv node. These tests check the convolution operation with different kernel sizes, strides, and padding types, comparing the results with known expected outputs.