### PR TITLE
Add Feature: add Node

### DIFF
--- a/src/Add_node.tpp
+++ b/src/Add_node.tpp
@@ -35,6 +35,9 @@ void AddNode<T>::forward() {
 
   // Valid case:
   if (A_shape == B_shape) {
+    if (C->get_shape() != A_shape) {
+      C->reshape(A_shape);  // Reshape output tensor to be the same as input tensors
+    }
     arithmetic.add(A, B, C);
     // Broadcasting case:
   } else if (broadcast_comp) {

--- a/src/Add_node.tpp
+++ b/src/Add_node.tpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "Add_node.hpp"
+
+template <typename T>
+AddNode<T>::AddNode(shared_ptr<const AbstractTensor> A, shared_ptr<const AbstractTensor> B,
+                    shared_ptr<AbstractTensor> C)
+    : A(A), B(B), C(C) {}
+
+template <typename T>
+void AddNode<T>::forward() {
+  if (!areInputsFilled()) {
+    throw runtime_error("AddNode forward called without inputs being set");
+  }
+
+  auto A_shape = A->get_shape();
+  auto B_shape = B->get_shape();
+  auto A_rank = A_shape.size();
+  auto B_rank = B_shape.size();
+  auto max_rank = std::max(A_rank, B_rank);
+  bool broadcast_comp = true;
+
+  // Check if broadcasting is possible
+  for (int i = 0; i < max_rank; i++) {
+    int dim_A = (i < A_rank) ? A_shape[A_rank - 1 - i] : 1;
+    int dim_B = (i < B_rank) ? B_shape[B_rank - 1 - i] : 1;
+
+    // Valid if dimensions match or one of them is 1
+    if (dim_A != dim_B && dim_A != 1 && dim_B != 1) {
+      broadcast_comp = false;  // Incompatible for broadcasting
+    }
+  }
+
+  Arithmetic_mml<T> arithmetic;
+
+  // Valid case:
+  if (A_shape == B_shape) {
+    arithmetic.add(A, B, C);
+    // Broadcasting case:
+  } else if (broadcast_comp) {
+    broadcast_addition();
+    // Invalid case:
+  } else {
+    throw runtime_error("Incompatible shapes for addition attempt in AddNode. Broadcasting impossible.");
+  }
+}
+
+template <typename T>
+bool AddNode<T>::areInputsFilled() const {
+  return A && A->get_size() > 0 && B && B->get_size() > 0;
+}
+
+template <typename T>
+void AddNode<T>::setInputs(const array_mml<GeneralDataTypes>& inputs) {
+  if (inputs.size() != 2) {
+    throw runtime_error("AddNode expects 2 inputs");
+  }
+
+  auto valueA = std::get_if<shared_ptr<AbstractTensor>>(&inputs[0]);
+  auto valueB = std::get_if<shared_ptr<AbstractTensor>>(&inputs[1]);
+
+  if (!valueA || !valueB) {
+    throw runtime_error("Failed to cast inputs to the expected tensor types.");
+  }
+
+  A = *valueA;
+  B = *valueB;
+}
+
+template <typename T>
+bool AddNode<T>::areOutputsFilled() const {
+  return C && C->get_size() > 0;
+}
+
+template <typename T>
+array_mml<GeneralDataTypes> AddNode<T>::getOutputs() const {
+  return array_mml<GeneralDataTypes>{GeneralDataTypes(std::static_pointer_cast<AbstractTensor>(C))};
+}
+
+template <typename T>
+void AddNode<T>::broadcast_addition() const {
+  auto A_shape = A->get_shape();
+  auto B_shape = B->get_shape();
+  auto A_rank = A_shape.size();
+  auto B_rank = B_shape.size();
+  auto max_rank = std::max(A_rank, B_rank);
+
+  // Compute output shape based on broadcasting rules
+  array_mml<int> output_shape(max_rank);
+  std::fill(output_shape.begin(), output_shape.end(), 1);
+  for (int i = 0; i < max_rank; i++) {
+    int dim_A = (i < A_rank) ? A_shape[A_rank - 1 - i] : 1;
+    int dim_B = (i < B_rank) ? B_shape[B_rank - 1 - i] : 1;
+
+    switch ((dim_A == dim_B) ? 0 : (dim_A == 1) ? 1
+                               : (dim_B == 1)   ? 2
+                                                : 3) {
+      case 0:
+        output_shape[max_rank - 1 - i] = dim_A;
+        break;
+      case 1:
+        output_shape[max_rank - 1 - i] = dim_B;
+        break;
+      case 2:
+        output_shape[max_rank - 1 - i] = dim_A;
+        break;
+      default:
+        throw std::runtime_error("Incompatible shapes for broadcasting.");
+    }
+  }
+
+  C->reshape(output_shape);
+
+  vector<int> A_strides(A_rank, 1);
+  vector<int> B_strides(B_rank, 1);
+  vector<int> output_strides(max_rank, 1);
+
+  // Compute strides for each tensor
+  for (int i = max_rank - 2; i >= 0; --i) {
+    output_strides[i] = output_strides[i + 1] * output_shape[i + 1];
+  }
+  for (int i = A_rank - 2; i >= 0; --i) {
+    A_strides[i] = A_strides[i + 1] * A_shape[i + 1];
+  }
+  for (int i = B_rank - 2; i >= 0; --i) {
+    B_strides[i] = B_strides[i + 1] * B_shape[i + 1];
+  }
+
+  // Iterate through the output tensor
+  for (int flat_idx = 0; flat_idx < C->get_size(); flat_idx++) {
+    int A_idx = 0, B_idx = 0;
+    int remaining = flat_idx;
+
+    // Compute multi-dimensional indices on the fly
+    for (int j = 0; j < max_rank; j++) {
+      int coord = remaining / output_strides[j];  // Extract coordinate for dim j
+      remaining %= output_strides[j];
+
+      int dim_A = (j < A_rank) ? A_shape[A_rank - max_rank + j] : 1;
+      int dim_B = (j < B_rank) ? B_shape[B_rank - max_rank + j] : 1;
+
+      if (dim_A > 1) A_idx += coord * A_strides[j];
+      if (dim_B > 1) B_idx += coord * B_strides[j];
+    }
+
+    // Perform element-wise addition
+    T value_A = (*A)[A_idx];
+    T value_B = (*B)[B_idx];
+    (*C)[flat_idx] = value_A + value_B;
+  }
+}

--- a/src/include/Add_node.hpp
+++ b/src/include/Add_node.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "a_node.hpp"
+#include "a_tensor.hpp"
+#include "globals.hpp"
+#include "mml_arithmetic.hpp"
+
+template <typename T>
+class AddNode : Node {
+  static_assert(
+      std::is_same_v<T, float> ||
+          std::is_same_v<T, double> ||
+          std::is_same_v<T, int32_t> ||
+          std::is_same_v<T, int64_t>,
+      "AddNode supports only float, double, int32_t, int64_t");
+
+ public:
+  using AbstractTensor = Tensor<T>;
+
+  /**
+   * @brief Constructor for AddNode.
+   *
+   * @param A Shared pointer to the first input tensor.
+   * @param B Shared pointer to the second input tensor.
+   * @param C Shared pointer to the output tensor.
+   */
+  AddNode(shared_ptr<const AbstractTensor> A, shared_ptr<const AbstractTensor> B,
+          shared_ptr<AbstractTensor> C);
+
+  /**
+   * @brief Performs element-wise binary addition in the two input tensors and stores the result in the output tensor.
+   */
+  void forward() override;
+
+  /**
+   * @brief Check if the input(s) are filled.
+   */
+  bool areInputsFilled() const override;
+
+  /**
+   * @brief Set the input(s) for the node.
+   *
+   * @param inputs The input data to be set, where inputs[0] is the data tensor and inputs[1] is the shape tensor.
+   */
+  void setInputs(const array_mml<GeneralDataTypes>& inputs) override;
+
+  /**
+   * @brief Check if the output(s) are filled.
+   */
+  bool areOutputsFilled() const override;
+
+  /**
+   * @brief Get the output of the node.
+   *
+   * @return The output data.
+   */
+  array_mml<GeneralDataTypes> getOutputs() const override;
+
+ private:
+  // tensors
+  shared_ptr<const AbstractTensor> A;  // Input tensor A
+  shared_ptr<const AbstractTensor> B;  // Input tensor B
+  shared_ptr<AbstractTensor> C;        // Output tensor C
+
+  /**
+   * @brief Helper function used when broadcasting addition is required.
+   * Likely only temporary to be replaced with something that can be used in multiple nodes instead.
+   *
+   * @return The output data.
+   */
+  void broadcast_addition() const;
+};
+
+#include "../Add_node.tpp"

--- a/src/include/a_arithmetic_module.hpp
+++ b/src/include/a_arithmetic_module.hpp
@@ -26,7 +26,7 @@ class ArithmeticModule {
   /// @param a The first tensor.
   /// @param b The second tensor structure.
   /// @param c The tensor structure to store the result.
-  virtual void add(const shared_ptr<Tensor<T>> a, const shared_ptr<Tensor<T>> b, shared_ptr<Tensor<T>> c) const = 0;
+  virtual void add(const shared_ptr<const Tensor<T>> a, const shared_ptr<const Tensor<T>> b, shared_ptr<Tensor<T>> c) const = 0;
 
   /// @brief Subtract one tensor structure from another.
   /// @param a The tensor structure to subtract from.

--- a/src/include/mml_arithmetic.hpp
+++ b/src/include/mml_arithmetic.hpp
@@ -15,7 +15,7 @@ class Arithmetic_mml : public ArithmeticModule<T> {
 
   ~Arithmetic_mml() override;
 
-  void add(const shared_ptr<Tensor<T>> a, const shared_ptr<Tensor<T>> b, shared_ptr<Tensor<T>> c) const override;
+  void add(const shared_ptr<const Tensor<T>> a, const shared_ptr<const Tensor<T>> b, shared_ptr<Tensor<T>> c) const override;
 
   void subtract(const shared_ptr<Tensor<T>> a, const shared_ptr<Tensor<T>> b, shared_ptr<Tensor<T>> c) const override;
 

--- a/src/include/modularml
+++ b/src/include/modularml
@@ -5,6 +5,7 @@
 #include "Swish_node.hpp"
 #include "Dropout_node.hpp"
 #include "reshape_node.hpp"
+#include "Add_node.hpp"
 #include "a_arithmetic_module.hpp"
 #include "a_data_parser.hpp"
 #include "a_gemm.hpp"

--- a/src/mml_arithmetic.tpp
+++ b/src/mml_arithmetic.tpp
@@ -15,7 +15,7 @@ template <typename T>
 Arithmetic_mml<T>::~Arithmetic_mml() = default;
 
 template <typename T>
-void Arithmetic_mml<T>::add(const shared_ptr<Tensor<T>> a, const shared_ptr<Tensor<T>> b, shared_ptr<Tensor<T>> c) const {
+void Arithmetic_mml<T>::add(const shared_ptr<const Tensor<T>> a, const shared_ptr<const Tensor<T>> b, shared_ptr<Tensor<T>> c) const {
   const auto size = a->get_size();
   for (int i = 0; i < size; i++) {
     (*c)[i] = (*a)[i] + (*b)[i];

--- a/tests/test_Add_node.cpp
+++ b/tests/test_Add_node.cpp
@@ -182,3 +182,63 @@ TEST(AddNodeTest, AddNodeTest_Broadcasting_IncompatibleShapes) {
    */
   EXPECT_THROW(addNode.forward(), std::runtime_error);
 }
+
+TEST(AddNodeTest, AddNodeTest_int) {
+  /**
+   * @brief Expected result tensor.
+   */
+  auto b = tensor_mml_p<int>({1, 2}, {3, 5});  // A + B expected output
+
+  /**
+   * @brief Input tensors.
+   */
+  auto A = tensor_mml_p<int>({1, 2}, {1, 2});  // Input A
+  auto B = tensor_mml_p<int>({1, 2}, {2, 3});  // Input B
+
+  auto A_ref = A;
+  auto B_ref = B;
+
+  /**
+   * @brief Output tensor.
+   */
+  auto C = tensor_mml_p<int>({1, 2});
+
+  AddNode<int> addNode(A, B, C);
+  addNode.forward();
+
+  // Check if the output tensor is correct
+  ASSERT_EQ(*b, *C);
+  // Check if the input tensors are unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}
+
+TEST(AddNodeTest, AddNodeTest_Broadcasting_int) {
+  /**
+   * @brief Expected result tensor.
+   */
+  auto b = tensor_mml_p<int>({1, 2}, {3, 4});  // A + B expected output after broadcasting
+
+  /**
+   * @brief Input tensors.
+   */
+  auto A = tensor_mml_p<int>({1, 2}, {1, 2});  // Input A (1x2)
+  auto B = tensor_mml_p<int>({1, 1}, {2});     // Input B (1x1) - needs broadcasting
+
+  auto A_ref = A;
+  auto B_ref = B;
+
+  /**
+   * @brief Output tensor.
+   */
+  auto C = tensor_mml_p<int>({1, 2});  // Output tensor (expected to match A's shape after broadcasting B)
+
+  AddNode<int> addNode(A, B, C);
+  addNode.forward();  // Should invoke broadcast addition
+
+  // Ensure output tensor is correct
+  ASSERT_EQ(*b, *C);
+  // Ensure input tensors remain unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}

--- a/tests/test_Add_node.cpp
+++ b/tests/test_Add_node.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+
+#include <modularml>
+
+TEST(AddNodeTest, AddNodeTest_float) {
+  /**
+   * @brief Expected result tensor.
+   */
+  auto b = tensor_mml_p<float>({1, 2}, {3.0f, 5.0f});  // A + B expected output
+
+  /**
+   * @brief input tensors.
+   */
+  auto A = tensor_mml_p<float>({1, 2}, {1.0f, 2.0f});  // Input A
+  auto B = tensor_mml_p<float>({1, 2}, {2.0f, 3.0f});  // Input B
+
+  auto A_ref = A;
+  auto B_ref = B;
+
+  /**
+   * @brief output tensor.
+   */
+  auto C = tensor_mml_p<float>({1, 2});
+
+  AddNode<float> addNode(A, B, C);
+  addNode.forward();
+
+  // Check if the output tensor is correct
+  ASSERT_EQ(*b, *C);
+  // Check if the input tensors are unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}
+
+TEST(AddNodeTest, AddNodeTest_Broadcasting_float) {
+  /**
+   * @brief Expected result tensor.
+   */
+  auto b = tensor_mml_p<float>({1, 2}, {3.0f, 4.0f});  // A + B expected output after broadcasting
+
+  /**
+   * @brief Input tensors.
+   */
+  auto A = tensor_mml_p<float>({1, 2}, {1.0f, 2.0f});  // Input A (1x2)
+  auto B = tensor_mml_p<float>({1, 1}, {2.0f});        // Input B (1x1) - needs broadcasting
+
+  auto A_ref = A;
+  auto B_ref = B;
+
+  /**
+   * @brief Output tensor.
+   */
+  auto C = tensor_mml_p<float>({1, 2});  // Output tensor (expected to match A's shape after broadcasting B)
+
+  AddNode<float> addNode(A, B, C);
+  addNode.forward();  // Should invoke broadcast addition
+
+  // Ensure output tensor is correct
+  ASSERT_EQ(*b, *C);
+  // Ensure input tensors remain unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}
+
+TEST(AddNodeTest, AddNodeTest_Broadcasting_Complex_float) {
+  /**
+   * @brief Expected result tensor.
+   * B should be broadcasted across dimensions [0] and [2] to match A.
+   */
+  auto b = tensor_mml_p<float>(
+      {2, 3, 4},  // Shape (2x3x4)
+      {
+          3.0f, 4.0f, 5.0f, 6.0f, 9.0f, 10.0f, 11.0f, 12.0f, 15.0f, 16.0f, 17.0f, 18.0f,
+          15.0f, 16.0f, 17.0f, 18.0f, 21.0f, 22.0f, 23.0f, 24.0f, 27.0f, 28.0f, 29.0f, 30.0f});
+
+  /**
+   * @brief Input tensors.
+   * A is (2,3,4), B is (1,3,1) -> Needs broadcasting along dimensions [0] and [2]
+   */
+  auto A = tensor_mml_p<float>(
+      {2, 3, 4},
+      {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f,
+       13.0f, 14.0f, 15.0f, 16.0f, 17.0f, 18.0f, 19.0f, 20.0f, 21.0f, 22.0f, 23.0f, 24.0f});
+
+  auto B = tensor_mml_p<float>(
+      {1, 3, 1},  // Shape (1x3x1) - needs broadcasting
+      {
+          2.0f, 4.0f, 6.0f  // Each row of A will be added with a different value
+      });
+
+  auto A_ref = A;  // Reference copy of A
+  auto B_ref = B;  // Reference copy of B
+
+  /**
+   * @brief Output tensor.
+   */
+  auto C = tensor_mml_p<float>({2, 3, 4});  // Output tensor
+
+  AddNode<float> addNode(A, B, C);
+  addNode.forward();  // Should invoke broadcast addition
+
+  // Ensure output tensor is correct
+  ASSERT_EQ(*b, *C);
+
+  // Ensure input tensors remain unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}
+
+TEST(AddNodeTest, AddNodeTest_Broadcasting_Simple_A_Broadcasts) {
+  /**
+   * @brief Expected result tensor.
+   * A should be broadcasted along dimension 0 to match B.
+   */
+  auto b = tensor_mml_p<float>(
+      {2, 3},  // Shape (2x3)
+      {
+          3.0f, 5.0f, 7.0f,  // A's values (1,2,3) broadcasted across row 0
+          6.0f, 8.0f, 10.0f  // A's values (1,2,3) broadcasted across row 1
+      });
+
+  /**
+   * @brief Input tensors.
+   * A is (1,3), B is (2,3) -> A needs broadcasting along dimension 0
+   */
+  auto A = tensor_mml_p<float>(
+      {1, 3},  // Shape (1x3)
+      {
+          1.0f, 2.0f, 3.0f  // Will be expanded to match B's shape (2,3)
+      });
+
+  auto B = tensor_mml_p<float>(
+      {2, 3},  // Shape (2x3)
+      {
+          2.0f, 3.0f, 4.0f,
+          5.0f, 6.0f, 7.0f});
+
+  auto A_ref = A;  // Reference copy of A
+  auto B_ref = B;  // Reference copy of B
+
+  /**
+   * @brief Output tensor.
+   */
+  auto C = tensor_mml_p<float>({2, 3});  // Output tensor
+
+  AddNode<float> addNode(A, B, C);
+  addNode.forward();  // Should invoke broadcast addition
+
+  // Ensure output tensor is correct
+  ASSERT_EQ(*b, *C);
+
+  // Ensure input tensors remain unchanged
+  ASSERT_EQ(*A, *A_ref);
+  ASSERT_EQ(*B, *B_ref);
+}
+
+TEST(AddNodeTest, AddNodeTest_Broadcasting_IncompatibleShapes) {
+  /**
+   * @brief Input tensors with incompatible shapes.
+   * A is (2,3), B is (3,2) -> Cannot be broadcasted.
+   */
+  auto A = tensor_mml_p<float>(
+      {2, 3},
+      {1.0f, 2.0f, 3.0f,
+       4.0f, 5.0f, 6.0f});
+
+  auto B = tensor_mml_p<float>(
+      {3, 2},
+      {7.0f, 8.0f,
+       9.0f, 10.0f,
+       11.0f, 12.0f});
+
+  /**
+   * @brief Output tensor (should never be created due to the error).
+   */
+  auto C = tensor_mml_p<float>({2, 3});  // This should not be used.
+
+  AddNode<float> addNode(A, B, C);
+
+  /**
+   * @brief Expect a runtime error due to incompatible broadcasting.
+   */
+  EXPECT_THROW(addNode.forward(), std::runtime_error);
+}


### PR DESCRIPTION

### Description
Added the add node with working broadcasting \& tests for it.

Also made a minor change to the add function inside of tensor. Currently, in main, it inputs `const shared_ptr<Tensor<T>> a, const shared_ptr<Tensor<T>> b, shared_ptr<Tensor<T>> c`, but I changed it so that it inputs `const shared_ptr<const Tensor<T>> a, const shared_ptr<const Tensor<T>> b, shared_ptr<Tensor<T>> c` to more closely resemble the way that we treat inputs inside of the nodes atm. Tested compiling the current version of main with this change and it caused no issues. We might want to change some of the other functions inside of tensor to reflect this as well at a later point.
### Issue
Closes #123